### PR TITLE
add a row facade wrapper and type conversion intended to be done on access

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ GEM
   specs:
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
-    fast_jsonparser (0.6.0)
     jwt (2.7.1)
     oj (3.16.1)
 
@@ -13,7 +12,6 @@ PLATFORMS
 DEPENDENCIES
   concurrent-ruby
   connection_pool
-  fast_jsonparser
   jwt
   oj
 

--- a/indifferent_case_insensitive_hash.rb
+++ b/indifferent_case_insensitive_hash.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class IndifferentCaseInsensitiveHash < Hash
+  def [](key)
+    super normalize_key(key)
+  end
+
+  def []=(key, value)
+    super normalize_key(key), value
+  end
+
+  private
+
+  def normalize_key(key)
+    if key.is_a?(Symbol)
+      key.to_s.downcase
+    elsif key.respond_to?(:downcase)
+      key.downcase
+    else
+      key
+    end
+  end
+end

--- a/row_facade.rb
+++ b/row_facade.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "time"
+
+class RowFacade
+  def initialize(row_types, column_to_index, data)
+    @row_types = row_types
+    @data = data
+    @column_to_index = column_to_index
+  end
+
+  # see: https://docs.snowflake.com/en/developer-guide/sql-api/handling-responses#getting-the-data-from-the-results
+  def [](column)
+    index = column.is_a?(Numeric) ? column.to_i : @column_to_index[column]
+    return nil if index.nil?
+
+    # TODO: double check these timestamp conversions, they may be wrong, I did not test them much
+    case @row_types[index]
+    when :time, :timestamp_ltz, :timestamp_ntz
+      Time.at(@data[index].to_f)
+    when :timestamp_tz
+      timestamp, offset_minutes = @data[index].split(" ")
+      Time.at(timestamp.to_f - offset_minutes.to_i * 60)
+    when :boolean
+      @data[index] == "true"
+    else
+      @data[index]
+    end
+  end
+
+  def to_h
+    output = IndifferentCaseInsensitiveHash.new
+    @column_to_index.each_pair do |name, index|
+      output[name] = self[index]
+    end
+    output
+  end
+
+  def to_s
+    to_h.to_s
+  end
+end

--- a/test.rb
+++ b/test.rb
@@ -20,6 +20,14 @@ size = 1_000
   SELECT * FROM FIVETRAN_DATABASE.RINSED_WEB_PRODUCTION_MAMMOTH.EVENTS limit #{size};
   SQL
   end
+
+  # you can now data.first or data.each and get rows that act like hashes
+  # RowFacade does the parsing at access time right now
+  # data.first.tap do |row|
+  #   puts row
+  #   puts "#{row[:id]}, #{row[:code]}, #{row[:payload]}, #{row[:updated_at]}"
+  # end
+
   puts "Querying with #{size}; took #{bm.real} actual size #{data.size}"
   puts
   puts


### PR DESCRIPTION
you can do the following now:

```ruby
# will perform the query and download all of the data
result = client.query "select * from some_long_table_name" # returns a ResultSet instance
result.each do |row| # row is a RowFacade instance
  # you can access individual fields of the row with a symbol or string
  puts row[:id]
  puts row["other_field"]

  # type conversion currently happens in ruby, on the fly when accessed
  puts row[:updated_at] # will yield a Time object
end

# you can also call to_h on a row, and it will return a has with indifferent case insensitive access with
# type conversion performed
# calling to_s will also give you what you'd expect
result.first.to_h # => { id: 44, other_field: "foo", updated_at: 2023-11-20 16:22:19 -0600 }
``` 