### PR TITLE
Add alias for `fetch`

### DIFF
--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -127,6 +127,8 @@ module RubySnowflake
       retreive_result_set(response, streaming)
     end
 
+    alias fetch query
+
     def self.env_option(env_var_name, default_value)
       value = ENV[env_var_name]
       value.nil? || value.empty? ? default_value : ENV[env_var_name].to_i

--- a/lib/ruby_snowflake/version.rb
+++ b/lib/ruby_snowflake/version.rb
@@ -1,3 +1,3 @@
 module RubySnowflake
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe RubySnowflake::Client do
     let(:query) { "" }
     let(:result) { client.query(query) }
 
+    context "with the alias name `fetch`" do
+      let(:query) { "SELECT 1;" }
+      it "should work" do
+        result = client.fetch(query)
+
+        expect(result).to be_a(RubySnowflake::Result)
+        expect(result.length).to eq(1)
+        rows = result.get_all_rows
+        expect(rows).to eq(
+          [{"1" => 1}]
+        )
+      end
+    end
+
     context "when we can't connect" do
       before do
         allow(Net::HTTP).to receive(:start).and_raise("Some connection error")


### PR DESCRIPTION
This will make the client interface equivalent to our old gem
`ruby-snowflake-client`, making the interchange of these 2 much easier.
