### PR TITLE
Add `create_jwt_token` helper method

### DIFF
--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -156,6 +156,13 @@ module RubySnowflake
       value = ENV[env_var_name]
       value.nil? || value.empty? ? default_value : ENV[env_var_name].to_i
     end
+
+    # This method can be used to populate the JWT token used for authentication
+    # in tests that require time travel.
+    def create_jwt_token
+      @key_pair_jwt_auth_manager.jwt_token
+    end
+
     private_class_method :env_option
 
     private

--- a/lib/ruby_snowflake/version.rb
+++ b/lib/ruby_snowflake/version.rb
@@ -1,3 +1,3 @@
 module RubySnowflake
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
The method can be used to generate the JWT token used for
authentication. A scenario where this is useful is for tests that
require time travel and would end up generating and invalid JWT due to
being in the past.
