### PR TITLE
Upcase `database` & `warehouse` fields

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.0.0)
+    rb_snowflake_client (1.0.3)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)
       dotenv (>= 2.8)

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -136,8 +136,8 @@ module RubySnowflake
       response = nil
       connection_pool.with do |connection|
         request_body = {
-          "statement" => query, "warehouse" => warehouse,
-          "database" =>  database, "timeout" => @query_timeout
+          "statement" => query, "warehouse" => warehouse&.upcase,
+          "database" =>  database&.upcase, "timeout" => @query_timeout
         }
 
         response = request_with_auth_and_headers(

--- a/lib/ruby_snowflake/version.rb
+++ b/lib/ruby_snowflake/version.rb
@@ -1,3 +1,3 @@
 module RubySnowflake
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -21,6 +21,28 @@ RSpec.describe RubySnowflake::Client do
       end
     end
 
+    context "with lower case database name" do
+      let(:query) { "SELECT * from public.test_datatypes;" }
+
+      it "should work" do
+        result = client.fetch(query, database: "ruby_snowflake_client_testing")
+
+        expect(result).to be_a(RubySnowflake::Result)
+        expect(result.length).to eq(2)
+      end
+    end
+
+    context "with lower case warehouse name" do
+      let(:query) { "SELECT * from ruby_snowflake_client_testing.public.test_datatypes;" }
+
+      it "should work" do
+        result = client.fetch(query, warehouse: "web_data_load_wh")
+
+        expect(result).to be_a(RubySnowflake::Result)
+        expect(result.length).to eq(2)
+      end
+    end
+
     context "when we can't connect" do
       before do
         allow(Net::HTTP).to receive(:start).and_raise("Some connection error")


### PR DESCRIPTION
The fields are case sensitive as per Snowflake's api [1]. If we pass
**NOT** upcased fields we get errors like:

```ruby

RubySnowflake::BadResponseError: Bad response! Got code: 422, w/ message {
  "code" : "391918",
  "message": "Unable to run <command> without specifying
database/warehouse"
}
```

[1]: https://docs.snowflake.com/en/developer-guide/sql-api/submitting-requests