### PR TITLE
pass an exponential backoff to retryable.retry

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.0.4)
+    rb_snowflake_client (1.0.5)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)
       dotenv (>= 2.8)

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -190,6 +190,7 @@ module RubySnowflake
         request.body = body unless body.nil?
 
         Retryable.retryable(tries: @http_retries + 1,
+                            sleep: lambda {|n| 2**n }, # 1, 2, 4, 8, etc
                             on: [RetryableBadResponseError, OpenSSL::SSL::SSLError],
                             log_method: retryable_log_method) do
           response = nil

--- a/lib/ruby_snowflake/version.rb
+++ b/lib/ruby_snowflake/version.rb
@@ -1,3 +1,3 @@
 module RubySnowflake
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end


### PR DESCRIPTION
Pass an exponential backoff lambda for calculating the number of seconds to sleep when we hit retryable errors. In practice, this is almost always a 429 where we've exceeded the capacity of a warehouse temporarily.

I couldn't come up with a great way to test this separately, so I'm going to rely on Retryable having tested their sleep parameter well.