### PR TITLE
Allow specifying `schema` in `query` method

### DIFF
--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -128,7 +128,7 @@ module RubySnowflake
       @_enable_polling_queries = false
     end
 
-    def query(query, warehouse: nil, streaming: false, database: nil)
+    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil)
       warehouse ||= @default_warehouse
       database ||= @default_database
 
@@ -136,8 +136,11 @@ module RubySnowflake
       response = nil
       connection_pool.with do |connection|
         request_body = {
-          "statement" => query, "warehouse" => warehouse&.upcase,
-          "database" =>  database&.upcase, "timeout" => @query_timeout
+          "database" =>  database&.upcase,
+          "schema" => schema&.upcase,
+          "statement" => query,
+          "timeout" => @query_timeout,
+          "warehouse" => warehouse&.upcase,
         }
 
         response = request_with_auth_and_headers(

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe RubySnowflake::Client do
       end
     end
 
+    context "with lower case schema name" do
+      let(:query) { "SELECT * from test_datatypes;" }
+
+      it "should work" do
+        result = client.fetch(query, database: "ruby_snowflake_client_testing", schema: "public")
+
+        expect(result).to be_a(RubySnowflake::Result)
+        expect(result.length).to eq(2)
+      end
+    end
+
     context "with lower case warehouse name" do
       let(:query) { "SELECT * from ruby_snowflake_client_testing.public.test_datatypes;" }
 


### PR DESCRIPTION
It seems that some operations (e.g. `COPY INTO`) require passing the schema via an api param, rather than in the text of the SQL query.