### PR TITLE
Raise clearer errors when configs are Missing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.1.0)
+    rb_snowflake_client (1.1.1)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)
       dotenv (>= 2.8)
@@ -50,17 +50,11 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
-  concurrent-ruby
-  connection_pool
-  dotenv
-  jwt
-  oj
   parallel
   pry
   rake
   rb_snowflake_client!
-  retryable
   rspec
 
 BUNDLED WITH
-   2.5.4
+   2.5.10

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -3,6 +3,14 @@ require "spec_helper"
 RSpec.describe RubySnowflake::Client do
   let(:client) { described_class.from_env }
 
+  describe "initialization" do
+    context "when the environment variables are not set" do
+      it "should raise an error" do
+        expect { client }.to raise_error(RubySnowflake::MissingConfig)
+      end
+    end
+  end
+
   describe "querying" do
     let(:query) { "" }
     let(:result) { client.query(query) }

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -5,6 +5,17 @@ RSpec.describe RubySnowflake::Client do
 
   describe "initialization" do
     context "when the environment variables are not set" do
+      around do |example|
+        old_env = ENV.to_h
+
+        begin
+          ENV.clear
+          example.run
+        ensure
+          ENV.replace(old_env)
+        end
+      end
+
       it "should raise an error" do
         expect { client }.to raise_error(RubySnowflake::MissingConfig)
       end


### PR DESCRIPTION
e.g. currently if SNOWFLAKE_PRIVATE_KEY and SNOWFLAKE_PRIVATE_KEY_PATH
are not set, the error message is:
```TypeError: no implicit conversion of nil into String```

Also: Update Gemfile.lock. It had gotten outdated.


