### PR TITLE
Make organization optional, some folks can't auth by providing org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
-          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
       - name: Build gem
         run: rake build
       # Enable this section to allow debugging via SSH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/ruby-setup@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@904f3fef85a9c80a3750cbe7d5159268fd5caa9f
+        uses: ruby/ruby-setup@v1
         with:
-          ruby-version: '3.2.2'
-      - name: Install dependencies
-        run: bundle install
+          ruby-version: '3.3'
+          bundler-cache: true
       - name: Build gem
         run: rake build
       # Enable this section to allow debugging via SSH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@904f3fef85a9c80a3750cbe7d5159268fd5caa9f
         with:
-          ruby-version: '3.4.3'
+          ruby-version: '3.2.2'
       - name: Install dependencies
         run: bundle install
       - name: Build gem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@904f3fef85a9c80a3750cbe7d5159268fd5caa9f
         with:
-          ruby-version: '3.0.6'
+          ruby-version: '3.4.3'
       - name: Install dependencies
         run: bundle install
       - name: Build gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.2.0)
+    rb_snowflake_client (1.3.0)
       bigdecimal (>= 3.0)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ require "rb_snowflake_client"
 client = RubySnowflake::Client.new(
   "https://yourinstance.region.snowflakecomputing.com", # insert your URL here
   File.read("secrets/my_key.pem"),                      # your private key in PEM format (scroll down for instructions)
-  "snowflake-organization",                             # your account name (doesn't match your URL)
+  "snowflake-organization",                             # your account name (doesn't match your URL), using nil may be required depending on your snowflake account
   "snowflake-account",                                  # typically your subdomain
   "snowflake-user",                                     # Your snowflake user
   "some_warehouse",                                     # The name of your warehouse to use by default
@@ -49,6 +49,7 @@ Available ENV variables (see below in the config section for details)
 - `SNOWFLAKE_PRIVATE_KEY_PATH` or `SNOWFLAKE_PRIVATE_KEY`
   - Use either the key or the path. Key takes precedence if both are provided.
 - `SNOWFLAKE_ORGANIZATION`
+  - Optional, if you leave it off, the library will authenticate with an account name of only SNOWFLAKE_ACCOUNT
 - `SNOWFLAKE_ACCOUNT`
 - `SNOWFLAKE_USER`
 - `SNOWFLAKE_DEFAULT_WAREHOUSE`
@@ -215,7 +216,7 @@ or alternatively, use the client to verify:
 client = RubySnowflake::Client.new(
   "https://yourinstance.region.snowflakecomputing.com", # insert your URL here
   File.read("secrets/my_key.pem"),                      # path to your private key
-  "snowflake-organization",                             # your account name (doesn't match your URL)
+  "snowflake-organization",                             # your account name (doesn't match your URL), using nil may be required depending on your snowflake account
   "snowflake-account",                                  # typically your subdomain
   "snowflake-user",                                     # Your snowflake user
   "some_warehouse",                                     # The name of your warehouse to use by default

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -67,6 +67,8 @@ module RubySnowflake
     DEFAULT_HTTP_RETRIES = 2
     # how long to wait to allow a query to complete, in seconds
     DEFAULT_QUERY_TIMEOUT = 600 # 10 minutes
+    # default role to use
+    DEFAULT_ROLE = nil
 
     JSON_PARSE_OPTIONS = { decimal_class: BigDecimal }.freeze
     VALID_RESPONSE_CODES = %w(200 202).freeze
@@ -84,7 +86,8 @@ module RubySnowflake
                       max_threads_per_query: env_option("SNOWFLAKE_MAX_THREADS_PER_QUERY", DEFAULT_MAX_THREADS_PER_QUERY),
                       thread_scale_factor: env_option("SNOWFLAKE_THREAD_SCALE_FACTOR", DEFAULT_THREAD_SCALE_FACTOR),
                       http_retries: env_option("SNOWFLAKE_HTTP_RETRIES", DEFAULT_HTTP_RETRIES),
-                      query_timeout: env_option("SNOWFLAKE_QUERY_TIMEOUT", DEFAULT_QUERY_TIMEOUT))
+                      query_timeout: env_option("SNOWFLAKE_QUERY_TIMEOUT", DEFAULT_QUERY_TIMEOUT),
+                      default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE))
       private_key =
         if key = ENV["SNOWFLAKE_PRIVATE_KEY"]
           key

--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -30,8 +30,8 @@ module RubySnowflake
           private_key = OpenSSL::PKey.read(@private_key_pem)
 
           payload = {
-            :iss => "#{@organization.upcase}-#{@account.upcase}.#{@user.upcase}.#{public_key_fingerprint}",
-            :sub => "#{@organization.upcase}-#{@account.upcase}.#{@user.upcase}",
+            :iss => "#{account_name}.#{@user.upcase}.#{public_key_fingerprint}",
+            :sub => "#{account_name}.#{@user.upcase}",
             :iat => now,
             :exp => @token_expires_at
           }
@@ -43,6 +43,14 @@ module RubySnowflake
       private
         def jwt_token_expired?
           Time.now.to_i > @token_expires_at
+        end
+
+        def account_name
+          if @organization == nil || @organization == ""
+            @account.upcase
+          else
+            "#{@organization.upcase}-#{@account.upcase}"
+          end
         end
 
         def public_key_fingerprint

--- a/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
+++ b/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+
+RSpec.describe RubySnowflake::Client::KeyPairJwtAuthManager do
+  let(:organization) { nil }
+  let(:account) { "account" }
+  let(:user) { "user" }
+  let(:private_key) { OpenSSL::PKey::RSA.new(2048).to_pem }
+  let(:jwt_token_ttl) { 3600 }
+  
+  subject { described_class.new(organization, account, user, private_key, jwt_token_ttl) }
+
+  describe "#jwt_token" do
+    context "when creating a JWT token" do
+      it "generates a valid token" do
+        expect(subject.jwt_token).to be_a(String)
+      end
+      
+      it "generates a token with the correct claims" do
+        # Use the JWT gem to decode the token
+        token = subject.jwt_token
+        decoded_token = JWT.decode(token, OpenSSL::PKey::RSA.new(private_key).public_key, true, { algorithm: 'RS256' })[0]
+        
+        expect(decoded_token["iss"]).to include(account.upcase)
+        expect(decoded_token["iss"]).to include(user.upcase)
+        expect(decoded_token["sub"]).to eq("#{account.upcase}.#{user.upcase}")
+        expect(decoded_token["iat"]).to be_a(Integer)
+        expect(decoded_token["exp"]).to be_a(Integer)
+      end
+      
+      it "creates token with proper expiration time" do
+        now = Time.now.to_i
+        token = subject.jwt_token
+        decoded_token = JWT.decode(token, OpenSSL::PKey::RSA.new(private_key).public_key, true, { algorithm: 'RS256' })[0]
+        
+        # Expect the token to expire in approximately jwt_token_ttl seconds
+        expect(decoded_token["exp"] - now).to be_within(5).of(jwt_token_ttl)
+      end
+    end
+  end
+  
+  describe "account_name handling" do
+    context "when organization is nil" do
+      let(:organization) { nil }
+      
+      it "uses only the account in the token" do
+        token = subject.jwt_token
+        decoded_token = JWT.decode(token, OpenSSL::PKey::RSA.new(private_key).public_key, true, { algorithm: 'RS256' })[0]
+        
+        expect(decoded_token["iss"]).to start_with("#{account.upcase}.")
+        expect(decoded_token["sub"]).to eq("#{account.upcase}.#{user.upcase}")
+      end
+    end
+    
+    context "when organization is empty string" do
+      let(:organization) { "" }
+      
+      it "uses only the account in the token" do
+        token = subject.jwt_token
+        decoded_token = JWT.decode(token, OpenSSL::PKey::RSA.new(private_key).public_key, true, { algorithm: 'RS256' })[0]
+        
+        expect(decoded_token["iss"]).to start_with("#{account.upcase}.")
+        expect(decoded_token["sub"]).to eq("#{account.upcase}.#{user.upcase}")
+      end
+    end
+    
+    context "when organization is provided" do
+      let(:organization) { "org" }
+      
+      it "uses org-account format in the token" do
+        token = subject.jwt_token
+        decoded_token = JWT.decode(token, OpenSSL::PKey::RSA.new(private_key).public_key, true, { algorithm: 'RS256' })[0]
+        
+        expect(decoded_token["iss"]).to start_with("#{organization.upcase}-#{account.upcase}.")
+        expect(decoded_token["sub"]).to eq("#{organization.upcase}-#{account.upcase}.#{user.upcase}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The snowflake docs say one thing and give an example of another, so allow both providing it and not providing it
The docs have an example using ORGANIZATION-ACCOUNT but also say maybe not to. It's been working for our multiple accounts and enterprise setup to have it in, but others report not being able to connect without patching the gem, so I'm allowing a nil value for organization and then just omitting it and the extra dash

Docs: https://docs.snowflake.com/en/developer-guide/snowflake-rest-api/authentication#generate-a-jwt-token

Issue: https://github.com/rinsed-org/rb-snowflake-client/issues/82

And thanks to @dymcode for the [PR](https://github.com/rinsed-org/rb-snowflake-client/pull/83) 