### PR TITLE
allow manual triggering of release workflow via the github UI / API

### DIFF
--- a/.github/workflows/release-gh-packages.yml
+++ b/.github/workflows/release-gh-packages.yml
@@ -1,5 +1,6 @@
 name: Release to Github Packages
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"

--- a/.github/workflows/release-rubygems.yml
+++ b/.github/workflows/release-rubygems.yml
@@ -1,5 +1,6 @@
 name: Release to Rubygems
 on:
+  workflow_dispatch:
   push:
     branches:
       - "master"


### PR DESCRIPTION
Because there was an error when we pushed a change to version, the workflows won't run again. This allows us to manually trigger them to run via GH UI or the API