### PR TITLE
Release records after they've been consumed in streaming mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Streaming mode now releases consumed records, fixing memory leak
+
 ## [1.4.0] - 2025-05-01
 ### Added
 - Enhanced Row API to implement Enumerable interface

--- a/lib/ruby_snowflake/streaming_result.rb
+++ b/lib/ruby_snowflake/streaming_result.rb
@@ -34,9 +34,10 @@ module RubySnowflake
 
         # After iterating over the current partition, clear the data to release memory
         data[index].clear
-        # Using a symbol so:
-        # - The results array can be GCd
+
+        # Reassign to a symbol so:
         # - When looking at the list of partitions in `data` it is easier to detect
+        # - Will raise an exception if `data.each` is attempted to be called again
         # - It won't trigger prefetch detection as `next_index`
         data[index] = :finished
       end

--- a/lib/ruby_snowflake/streaming_result.rb
+++ b/lib/ruby_snowflake/streaming_result.rb
@@ -33,6 +33,7 @@ module RubySnowflake
         end
 
         # After iterating over the current partition, clear the data to release memory
+        data[index].clear
         # Using a symbol so:
         # - The results array can be GCd
         # - When looking at the list of partitions in `data` it is easier to detect

--- a/lib/ruby_snowflake/streaming_result.rb
+++ b/lib/ruby_snowflake/streaming_result.rb
@@ -27,9 +27,17 @@ module RubySnowflake
         if data[index].is_a? Concurrent::Future
           data[index] = data[index].value # wait for it to finish
         end
+
         data[index].each do |row|
           yield wrap_row(row)
         end
+
+        # After iterating over the current partition, clear the data to release memory
+        # Using a symbol so:
+        # - The results array can be GCd
+        # - When looking at the list of partitions in `data` it is easier to detect
+        # - It won't trigger prefetch detection as `next_index`
+        data[index] = :finished
       end
     end
 


### PR DESCRIPTION
Fixes #126

When `Client#query` is called with the `streaming: true` option, records do not currently get released to GC as they are consumed. This change replaces a consumed partition with a single symbol to allow consumed partitions to be freed.

This technically represents a minor breaking change, as previously the streaming `Result` object could be iterated multiple times. I think that is unexpected for a streaming response anyway, so it's unlikely to be problematic.