### PR TITLE
ActiveSupport instrumentation on snowflake queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,15 @@ gemspec
 gem "bundler"
 gem "rake"
 
+group :development, :test do
+  gem "activesupport"
+end
+
 group :development do
   gem "parallel"
   gem "pry"
 end
 
 group :test do
-  gem "activesupport"
   gem "rspec"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,6 @@ group :development do
 end
 
 group :test do
-  gem "datadog"
+  gem "activesupport"
   gem "rspec"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,6 @@ group :development do
 end
 
 group :test do
+  gem "datadog"
   gem "rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,33 +13,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (8.0.3)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     base64 (0.2.0)
+    benchmark (0.4.1)
     bigdecimal (3.1.9)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
-    datadog (2.21.0)
-      datadog-ruby_core_source (~> 3.4, >= 3.4.1)
-      libdatadog (~> 18.1.0.1.0)
-      libddwaf (~> 1.24.1.2.1)
-      logger
-      msgpack
-    datadog-ruby_core_source (3.4.1)
     diff-lcs (1.6.1)
     dotenv (3.1.8)
-    ffi (1.17.2)
-    ffi (1.17.2-arm64-darwin)
+    drb (2.2.3)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
     json (2.11.3)
     jwt (2.10.1)
       base64
-    libdatadog (18.1.0.1.0)
-    libddwaf (1.24.1.2.1)
-      ffi (~> 1.0)
-    libddwaf (1.24.1.2.1-arm64-darwin)
-      ffi (~> 1.0)
     logger (1.7.0)
     method_source (1.1.0)
-    msgpack (1.8.0)
+    minitest (5.26.0)
     parallel (1.27.0)
     pry (0.15.2)
       coderay (~> 1.1)
@@ -59,14 +62,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
+    securerandom (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    uri (1.0.4)
 
 PLATFORMS
   arm64-darwin-22
   ruby
 
 DEPENDENCIES
+  activesupport
   bundler
-  datadog
   parallel
   pry
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,12 +18,28 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
+    datadog (2.21.0)
+      datadog-ruby_core_source (~> 3.4, >= 3.4.1)
+      libdatadog (~> 18.1.0.1.0)
+      libddwaf (~> 1.24.1.2.1)
+      logger
+      msgpack
+    datadog-ruby_core_source (3.4.1)
     diff-lcs (1.6.1)
     dotenv (3.1.8)
+    ffi (1.17.2)
+    ffi (1.17.2-arm64-darwin)
     json (2.11.3)
     jwt (2.10.1)
       base64
+    libdatadog (18.1.0.1.0)
+    libddwaf (1.24.1.2.1)
+      ffi (~> 1.0)
+    libddwaf (1.24.1.2.1-arm64-darwin)
+      ffi (~> 1.0)
+    logger (1.7.0)
     method_source (1.1.0)
+    msgpack (1.8.0)
     parallel (1.27.0)
     pry (0.15.2)
       coderay (~> 1.1)
@@ -50,6 +66,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  datadog
   parallel
   pry
   rake

--- a/README.md
+++ b/README.md
@@ -150,6 +150,33 @@ client.query(query, bindings: bindings)
 
 For additional information about binding parameters refer to snowflake documentation: https://docs.snowflake.com/en/developer-guide/sql-api/submitting-requests#using-bind-variables-in-a-statement
 
+## Instrumentation
+
+If ActiveSupport is available, this library additionally emits [notification events](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) around queries. You can subscribe to those to track timing, query counts, etc.
+
+* `rb_snowflake_client.snowflake_query.start`: published at query start
+* `rb_snowflake_client.snowflake_query.finish`: published at query end
+
+Both events receive a payload with the following properties
+* `query_name`: argument to query/fetch
+* `database`: argument to query/fetch
+* `schema`: argument to query/fetch
+* `warehouse`: argument to query/fetch
+* `query_id`: random UUID which is consistent between start and finish events for the same query
+
+An example integration with [Datadog](https://www.rubydoc.info/gems/datadog) might look like this:
+
+```ruby
+ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.start") do |event|
+  Datadog::Tracing.trace(event.payload[:query_name] || "snowflake_query",
+    type: Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_DB,
+    tags: event.payload,
+end
+ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.finish") do |event|
+  Datadog::Tracing.active_span&.finish
+end
+```
+
 # Configuration Options
 
 The client supports the following configuration options, each with their own getter/setter except connection pool options which must be set at construction. Additionally, all except logger can be configured with environment variables (see above, but the pattern is like: "SNOWFLAKE_HTTP_RETRIES". Configuration options can only be set on initialization through `new` or `from_env`.

--- a/README.md
+++ b/README.md
@@ -154,26 +154,28 @@ For additional information about binding parameters refer to snowflake documenta
 
 If ActiveSupport is available, this library additionally emits [notification events](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) around queries. You can subscribe to those to track timing, query counts, etc.
 
-* `rb_snowflake_client.snowflake_query.start`: published at query start
 * `rb_snowflake_client.snowflake_query.finish`: published at query end
 
-Both events receive a payload with the following properties
-* `query_name`: argument to query/fetch
-* `database`: argument to query/fetch
-* `schema`: argument to query/fetch
-* `warehouse`: argument to query/fetch
-* `query_id`: random UUID which is consistent between start and finish events for the same query
+Events receive a payload with the following properties:
+* `database`: snowflake database
+* `schema`: snowflake schema
+* `warehouse`: snowflake warehouse
+* `query_id`: random UUID for the query
+* `query_name`: argument passed to query/fetch
+* `exception`: present if the query raised an error, see [Notifications documentation](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#module-ActiveSupport::Notifications-label-Subscribers) for details
+* `exception_object`: present if the query raised an error, see [Notifications documentation](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#module-ActiveSupport::Notifications-label-Subscribers) for details
 
 An example integration with [Datadog](https://www.rubydoc.info/gems/datadog) might look like this:
 
 ```ruby
-ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.start") do |event|
-  Datadog::Tracing.trace(event.payload[:query_name] || "snowflake_query",
-    type: Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_DB,
-    tags: event.payload,
-end
-ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.finish") do |event|
-  Datadog::Tracing.active_span&.finish
+ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.finish") do |name, start, finish, id, payload|
+  span = Datadog::Tracing.trace(payload[:query_name] || "snowflake_query",
+    resource: "snowflake",
+    start_time: start,
+    tags: payload,
+    type: Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_DB)
+  
+  span.finish(finish)
 end
 ```
 

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -342,11 +342,10 @@ module RubySnowflake
         return block.call unless defined?(::ActiveSupport) && ::ActiveSupport
 
         enhanced_tags = tags.merge(query_id: SecureRandom.uuid)
+        event_name = "rb_snowflake_client.snowflake_query"
 
-        ::ActiveSupport::Notifications.publish("rb_snowflake_client.snowflake_query.start", enhanced_tags)
-        ::ActiveSupport::Notifications.instrument("rb_snowflake_client.snowflake_query.finish", enhanced_tags) do
-          block.call
-        end
+        ::ActiveSupport::Notifications.publish("#{event_name}.start", enhanced_tags)
+        ::ActiveSupport::Notifications.instrument("#{event_name}.finish", enhanced_tags) { block.call }
       end
   end
 end

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -149,8 +149,8 @@ module RubySnowflake
       @_enable_polling_queries = false
     end
 
-    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil)
-      with_instrumentation({ streaming: }) do
+    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil, query_name: nil)
+      with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
         warehouse ||= @default_warehouse
         database ||= @default_database
         role ||= @default_role

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -12,10 +12,10 @@ require "retryable"
 require "securerandom"
 require "uri"
 
-# Datadog is optional
 begin
-  require "datadog"
+  require "active_support"
 rescue LoadError
+  # This isn't required
 end
 
 require_relative "client/http_connection_wrapper"
@@ -339,10 +339,12 @@ module RubySnowflake
       end
 
       def with_instrumentation(tags, &block)
-        return block.call unless defined?(::Datadog) && ::Datadog
+        return block.call unless defined?(::ActiveSupport) && ::ActiveSupport
 
-        ::Datadog::Tracing.trace("snowflake_query") do |span|
-          tags.each { |key, value| span.set_tag(key, value) }
+        enhanced_tags = tags.merge(query_id: SecureRandom.uuid)
+
+        ::ActiveSupport::Notifications.publish("rb_snowflake_client.snowflake_query.start", enhanced_tags)
+        ::ActiveSupport::Notifications.instrument("rb_snowflake_client.snowflake_query.finish", enhanced_tags) do
           block.call
         end
       end

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -14,6 +14,7 @@ require "uri"
 
 begin
   require "active_support"
+  require "active_support/notifications"
 rescue LoadError
   # This isn't required
 end
@@ -150,11 +151,11 @@ module RubySnowflake
     end
 
     def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil, query_name: nil)
-      with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
-        warehouse ||= @default_warehouse
-        database ||= @default_database
-        role ||= @default_role
+      warehouse ||= @default_warehouse
+      database ||= @default_database
+      role ||= @default_role
 
+      with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
         query_start_time = Time.now.to_i
         response = nil
         connection_pool.with do |connection|
@@ -341,11 +342,11 @@ module RubySnowflake
       def with_instrumentation(tags, &block)
         return block.call unless defined?(::ActiveSupport) && ::ActiveSupport
 
-        enhanced_tags = tags.merge(query_id: SecureRandom.uuid)
-        event_name = "rb_snowflake_client.snowflake_query"
-
-        ::ActiveSupport::Notifications.publish("#{event_name}.start", enhanced_tags)
-        ::ActiveSupport::Notifications.instrument("#{event_name}.finish", enhanced_tags) { block.call }
+        ::ActiveSupport::Notifications.instrument(
+            "rb_snowflake_client.snowflake_query.finish",
+            tags.merge(query_id: SecureRandom.uuid)) do
+          block.call
+        end
       end
   end
 end

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -12,6 +12,12 @@ require "retryable"
 require "securerandom"
 require "uri"
 
+# Datadog is optional
+begin
+  require "datadog"
+rescue LoadError
+end
+
 require_relative "client/http_connection_wrapper"
 require_relative "client/key_pair_jwt_auth_manager"
 require_relative "client/single_thread_in_memory_strategy"
@@ -144,30 +150,32 @@ module RubySnowflake
     end
 
     def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil)
-      warehouse ||= @default_warehouse
-      database ||= @default_database
-      role ||= @default_role
+      with_instrumentation({ streaming: }) do
+        warehouse ||= @default_warehouse
+        database ||= @default_database
+        role ||= @default_role
 
-      query_start_time = Time.now.to_i
-      response = nil
-      connection_pool.with do |connection|
-        request_body = {
-          "warehouse" => warehouse&.upcase,
-          "schema" => schema&.upcase,
-          "database" =>  database&.upcase,
-          "statement" => query,
-          "bindings" => bindings,
-          "role" => role
-        }
+        query_start_time = Time.now.to_i
+        response = nil
+        connection_pool.with do |connection|
+          request_body = {
+            "warehouse" => warehouse&.upcase,
+            "schema" => schema&.upcase,
+            "database" =>  database&.upcase,
+            "statement" => query,
+            "bindings" => bindings,
+            "role" => role
+          }
 
-        response = request_with_auth_and_headers(
-          connection,
-          Net::HTTP::Post,
-          "/api/v2/statements?requestId=#{SecureRandom.uuid}&async=#{@_enable_polling_queries}",
-          request_body.to_json
-        )
+          response = request_with_auth_and_headers(
+            connection,
+            Net::HTTP::Post,
+            "/api/v2/statements?requestId=#{SecureRandom.uuid}&async=#{@_enable_polling_queries}",
+            request_body.to_json
+          )
+        end
+        retrieve_result_set(query_start_time, query, response, streaming)
       end
-      retrieve_result_set(query_start_time, query, response, streaming)
     end
 
     alias fetch query
@@ -328,6 +336,15 @@ module RubySnowflake
 
       def number_of_threads_to_use(partition_count)
         [[1, (partition_count / @thread_scale_factor.to_f).ceil].max, @max_threads_per_query].min
+      end
+
+      def with_instrumentation(tags, &block)
+        return block.call unless defined?(::Datadog) && ::Datadog
+
+        ::Datadog::Tracing.trace("snowflake_query") do |span|
+          tags.each { |key, value| span.set_tag(key, value) }
+          block.call
+        end
       end
   end
 end

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -23,14 +23,28 @@ RSpec.describe RubySnowflake::Client do
   end
 
   describe "querying" do
-    let(:query) { "" }
-    let(:result) { client.query(query) }
+    subject(:result) { client.query(query) }
+    let(:query) { "SELECT 1;" }
 
-    context "with the alias name `fetch`" do
-      let(:query) { "SELECT 1;" }
-      it "should work" do
-        result = client.fetch(query)
+    it "emits instrumentation events" do
+      start_event_received = false
+      finish_event_received = false
+      ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.start") do |*args|
+        start_event_received = true
+      end
+      ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.finish") do |*args|
+        finish_event_received = true
+      end
 
+      expect(result).to be_a(RubySnowflake::Result)
+      expect(start_event_received).to be(true)
+      expect(finish_event_received).to be(true)
+    end
+
+    context "with the 'fetch' alias" do
+      subject(:result) { client.fetch(query) }
+
+      it "works with 'fetch' alias" do
         expect(result).to be_a(RubySnowflake::Result)
         expect(result.length).to eq(1)
         rows = result.get_all_rows
@@ -41,8 +55,6 @@ RSpec.describe RubySnowflake::Client do
     end
 
     context "without ActiveSupport" do
-      let(:query) { "SELECT 1;" }
-
       around do |example|
         active_support = ::ActiveSupport
         ActiveSupport = nil
@@ -55,8 +67,6 @@ RSpec.describe RubySnowflake::Client do
       end
 
       it "should work" do
-        result = client.fetch(query)
-
         expect(result).to be_a(RubySnowflake::Result)
         expect(result.length).to eq(1)
         rows = result.get_all_rows
@@ -67,33 +77,31 @@ RSpec.describe RubySnowflake::Client do
     end
 
     context "with lower case database name" do
+      subject(:result) { client.fetch(query, database: "ruby_snowflake_client_testing") }
       let(:query) { "SELECT * from public.test_datatypes;" }
 
-      it "should work" do
-        result = client.fetch(query, database: "ruby_snowflake_client_testing")
 
+      it "should work" do
         expect(result).to be_a(RubySnowflake::Result)
         expect(result.length).to eq(2)
       end
     end
 
     context "with lower case schema name" do
+      subject(:result) { client.fetch(query, database: "ruby_snowflake_client_testing", schema: "public") }
       let(:query) { "SELECT * from test_datatypes;" }
 
       it "should work" do
-        result = client.fetch(query, database: "ruby_snowflake_client_testing", schema: "public")
-
         expect(result).to be_a(RubySnowflake::Result)
         expect(result.length).to eq(2)
       end
     end
 
     context "with lower case warehouse name" do
+      subject(:result) { client.fetch(query, warehouse: "web_data_load_wh") }
       let(:query) { "SELECT * from ruby_snowflake_client_testing.public.test_datatypes;" }
 
       it "should work" do
-        result = client.fetch(query, warehouse: "web_data_load_wh")
-
         expect(result).to be_a(RubySnowflake::Result)
         expect(result.length).to eq(2)
       end

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -40,17 +40,17 @@ RSpec.describe RubySnowflake::Client do
       end
     end
 
-    context "without Datadog" do
+    context "without ActiveSupport" do
       let(:query) { "SELECT 1;" }
 
       around do |example|
-        datadog = Datadog
-        Datadog = nil
+        active_support = ::ActiveSupport
+        ActiveSupport = nil
 
         begin
           example.run
         ensure
-          Datadog = datadog
+          ActiveSupport = active_support
         end
       end
 

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -27,24 +27,16 @@ RSpec.describe RubySnowflake::Client do
     let(:query) { "SELECT 1;" }
 
     it "emits instrumentation events" do
-      start_event_received = false
       finish_event_received = false
-      start_callback = lambda do |event|
-        expect(event.payload[:query_name]).to eq("test_query")
-        start_event_received = true
-      end
       finish_callback = lambda do |event|
         expect(event.payload[:query_name]).to eq("test_query")
         finish_event_received = true
       end
 
-      ActiveSupport::Notifications.subscribed(start_callback, "rb_snowflake_client.snowflake_query.start") do
-        ActiveSupport::Notifications.subscribed(finish_callback, "rb_snowflake_client.snowflake_query.finish") do
-          expect(result).to be_a(RubySnowflake::Result)
-        end
+      ActiveSupport::Notifications.subscribed(finish_callback, "rb_snowflake_client.snowflake_query.finish") do
+        expect(result).to be_a(RubySnowflake::Result)
       end
 
-      expect(start_event_received).to be(true)
       expect(finish_event_received).to be(true)
     end
 
@@ -62,15 +54,8 @@ RSpec.describe RubySnowflake::Client do
     end
 
     context "without ActiveSupport" do
-      around do |example|
-        active_support = ::ActiveSupport
-        ActiveSupport = nil
-
-        begin
-          example.run
-        ensure
-          ActiveSupport = active_support
-        end
+      before do
+        stub_const("ActiveSupport", nil) if defined?(ActiveSupport)
       end
 
       it "should work" do

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -40,6 +40,32 @@ RSpec.describe RubySnowflake::Client do
       end
     end
 
+    context "without Datadog" do
+      let(:query) { "SELECT 1;" }
+
+      around do |example|
+        datadog = Datadog
+        Datadog = nil
+
+        begin
+          example.run
+        ensure
+          Datadog = datadog
+        end
+      end
+
+      it "should work" do
+        result = client.fetch(query)
+
+        expect(result).to be_a(RubySnowflake::Result)
+        expect(result.length).to eq(1)
+        rows = result.get_all_rows
+        expect(rows).to eq(
+          [{"1" => 1}]
+        )
+      end
+    end
+
     context "with lower case database name" do
       let(:query) { "SELECT * from public.test_datatypes;" }
 

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -23,20 +23,27 @@ RSpec.describe RubySnowflake::Client do
   end
 
   describe "querying" do
-    subject(:result) { client.query(query) }
+    subject(:result) { client.query(query, query_name: "test_query") }
     let(:query) { "SELECT 1;" }
 
     it "emits instrumentation events" do
       start_event_received = false
       finish_event_received = false
-      ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.start") do |*args|
+      start_callback = lambda do |event|
+        expect(event.payload[:query_name]).to eq("test_query")
         start_event_received = true
       end
-      ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.finish") do |*args|
+      finish_callback = lambda do |event|
+        expect(event.payload[:query_name]).to eq("test_query")
         finish_event_received = true
       end
 
-      expect(result).to be_a(RubySnowflake::Result)
+      ActiveSupport::Notifications.subscribed(start_callback, "rb_snowflake_client.snowflake_query.start") do
+        ActiveSupport::Notifications.subscribed(finish_callback, "rb_snowflake_client.snowflake_query.finish") do
+          expect(result).to be_a(RubySnowflake::Result)
+        end
+      end
+
       expect(start_event_received).to be(true)
       expect(finish_event_received).to be(true)
     end


### PR DESCRIPTION
This will provide a mechanism for the consumer application to hook into the snowflake queries for instrumentation purposes.

For example, a consumer using Datadog might integrate like this:
```
ActiveSupport::Notifications.subscribe("rb_snowflake_client.snowflake_query.finish") do |event|
  span = Datadog::Tracing.trace(event.payload[:query_name] || "snowflake_query",
    type: Datadog::Tracing::Metadata::Ext::AppTypes::TYPE_DB,
    tags: event.payload)
  span.finish
end
```