### PR TITLE
Actually send the query timeout to snowflake, allow setting per query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Instrumentation feature added for Active Support users
+- Added `query_timeout` as a per-query parameter, allowing timeout override on individual queries
 ### Fixed
-- Streaming mode now releases consumed records, fixing memory leak
+- `query_timeout` now properly sends timeout parameter to Snowflake API for server-side enforcement
+- Streaming mode now releases consumed records, fixing memory leak. Note: if you were iterating over streaming results more than once, this is a breaking change (though that was not its intended usage).
 
 ## [1.4.0] - 2025-05-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,14 @@ Queries by default use the primary role assigned to the account. If there are mu
 client.query("SELECT * FROM BIGTABLE", role: "MY_ROLE")
 ```
 
+## Query timeout
+
+You can override the query timeout on a per-query basis. The timeout is specified in seconds and will be enforced by both Snowflake server-side and the client-side polling mechanism.
+
+```ruby
+client.query("SELECT * FROM BIGTABLE", query_timeout: 30)
+```
+
 ## Binding parameters
 
 Say we have `BIGTABLE` with a `data` column of a type `VARIANT`.


### PR DESCRIPTION
This addresses #128 - we'll now pass the timeout parameter in the query to snowflake.

Additionally, seemed to me we should probably allow this per-query as well so you can have a default and allow some long/slow query to have a different value. Had to pass the setting around as a method param around to maintain thread safety.