### PR TITLE
Improve StreamingResult iteration performance with parallel prefetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Streaming mode now prefetches partitions in parallel using multiple threads, dramatically improving iteration performance (4-5x faster). This uses slightly more memory than the previous single-threaded approach, but is now comparable in speed to non-streaming mode. Thread count is automatically calculated based on `max_threads_per_query` and `thread_scale_factor` settings.
 
 ## [1.5.0] - 2025-10-14
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.4.0)
+    rb_snowflake_client (1.5.0)
       bigdecimal (>= 3.0)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -311,7 +311,9 @@ module RubySnowflake
         retrieve_proc = ->(index) { retrieve_partition_data(statement_handle, index) }
 
         if streaming
-          StreamingResultStrategy.result(json_body, retrieve_proc)
+          # Use same thread calculation logic for streaming to enable parallel prefetching
+          # This dramatically improves iteration performance while maintaining memory efficiency
+          StreamingResultStrategy.result(json_body, retrieve_proc, prefetch_threads: num_threads)
         elsif num_threads == 1
           SingleThreadInMemoryStrategy.result(json_body, retrieve_proc)
         else

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -311,8 +311,6 @@ module RubySnowflake
         retrieve_proc = ->(index) { retrieve_partition_data(statement_handle, index) }
 
         if streaming
-          # Use same thread calculation logic for streaming to enable parallel prefetching
-          # This dramatically improves iteration performance while maintaining memory efficiency
           StreamingResultStrategy.result(json_body, retrieve_proc, prefetch_threads: num_threads)
         elsif num_threads == 1
           SingleThreadInMemoryStrategy.result(json_body, retrieve_proc)

--- a/lib/ruby_snowflake/client/streaming_result_strategy.rb
+++ b/lib/ruby_snowflake/client/streaming_result_strategy.rb
@@ -3,13 +3,14 @@
 module RubySnowflake
   class Client
     class StreamingResultStrategy
-      def self.result(statement_json_body, retreive_proc)
+      def self.result(statement_json_body, retreive_proc, prefetch_threads: 1)
         partitions = statement_json_body["resultSetMetaData"]["partitionInfo"]
 
         result = StreamingResult.new(
           partitions.size,
           statement_json_body["resultSetMetaData"]["rowType"],
-          retreive_proc
+          retreive_proc,
+          prefetch_threads: prefetch_threads
         )
         result[0] = statement_json_body["data"]
 

--- a/lib/ruby_snowflake/streaming_result.rb
+++ b/lib/ruby_snowflake/streaming_result.rb
@@ -17,41 +17,43 @@ module RubySnowflake
 
       thread_pool = Concurrent::FixedThreadPool.new(@prefetch_threads)
 
-      data.each_with_index do |_partition, index|
-        # Prefetch the next N partitions (where N = prefetch_threads)
-        # This allows parallel fetching while maintaining memory efficiency
-        @prefetch_threads.times do |offset|
-          next_index = index + offset + 1
-          break if next_index >= data.size
+      begin
+        data.each_with_index do |_partition, index|
+          # Prefetch the next N partitions (where N = prefetch_threads)
+          # This allows parallel fetching while maintaining memory efficiency
+          @prefetch_threads.times do |offset|
+            next_index = index + offset + 1
+            break if next_index >= data.size
 
-          if data[next_index].nil? # not yet fetched or prefetched
-            data[next_index] = Concurrent::Future.execute(executor: thread_pool) do
-              @retreive_proc.call(next_index)
+            if data[next_index].nil? # not yet fetched or prefetched
+              data[next_index] = Concurrent::Future.execute(executor: thread_pool) do
+                @retreive_proc.call(next_index)
+              end
             end
           end
+
+          if data[index].is_a? Concurrent::Future
+            data[index] = data[index].value # wait for it to finish
+          end
+
+          data[index].each do |row|
+            yield wrap_row(row)
+          end
+
+          # After iterating over the current partition, clear the data to release memory
+          data[index].clear
+
+          # Reassign to a symbol so:
+          # - When looking at the list of partitions in `data` it is easier to detect
+          # - Will raise an exception if `data.each` is attempted to be called again
+          # - It won't trigger prefetch detection as `next_index`
+          data[index] = :finished
         end
-
-        if data[index].is_a? Concurrent::Future
-          data[index] = data[index].value # wait for it to finish
-        end
-
-        data[index].each do |row|
-          yield wrap_row(row)
-        end
-
-        # After iterating over the current partition, clear the data to release memory
-        data[index].clear
-
-        # Reassign to a symbol so:
-        # - When looking at the list of partitions in `data` it is easier to detect
-        # - Will raise an exception if `data.each` is attempted to be called again
-        # - It won't trigger prefetch detection as `next_index`
-        data[index] = :finished
+      ensure
+        # Ensure thread pool is properly shut down even if an exception occurs
+        thread_pool.shutdown
+        thread_pool.wait_for_termination
       end
-
-      # Ensure thread pool is properly shut down
-      thread_pool.shutdown
-      thread_pool.wait_for_termination
     end
 
 

--- a/lib/ruby_snowflake/streaming_result.rb
+++ b/lib/ruby_snowflake/streaming_result.rb
@@ -6,21 +6,28 @@ require_relative "result"
 
 module RubySnowflake
   class StreamingResult < Result
-    def initialize(partition_count, row_type_data, retreive_proc)
+    def initialize(partition_count, row_type_data, retreive_proc, prefetch_threads: 1)
       super(partition_count, row_type_data)
       @retreive_proc = retreive_proc
+      @prefetch_threads = prefetch_threads
     end
 
     def each
       return to_enum(:each) unless block_given?
 
-      thread_pool = Concurrent::FixedThreadPool.new 1
+      thread_pool = Concurrent::FixedThreadPool.new(@prefetch_threads)
 
       data.each_with_index do |_partition, index|
-        next_index = [index+1, data.size-1].min
-        if data[next_index].nil? # prefetch
-          data[next_index] = Concurrent::Future.execute(executor: thread_pool) do
-            @retreive_proc.call(next_index)
+        # Prefetch the next N partitions (where N = prefetch_threads)
+        # This allows parallel fetching while maintaining memory efficiency
+        @prefetch_threads.times do |offset|
+          next_index = index + offset + 1
+          break if next_index >= data.size
+
+          if data[next_index].nil? # not yet fetched or prefetched
+            data[next_index] = Concurrent::Future.execute(executor: thread_pool) do
+              @retreive_proc.call(next_index)
+            end
           end
         end
 
@@ -41,6 +48,10 @@ module RubySnowflake
         # - It won't trigger prefetch detection as `next_index`
         data[index] = :finished
       end
+
+      # Ensure thread pool is properly shut down
+      thread_pool.shutdown
+      thread_pool.wait_for_termination
     end
 
 

--- a/lib/ruby_snowflake/streaming_result.rb
+++ b/lib/ruby_snowflake/streaming_result.rb
@@ -7,6 +7,8 @@ require_relative "result"
 module RubySnowflake
   class StreamingResult < Result
     def initialize(partition_count, row_type_data, retreive_proc, prefetch_threads: 1)
+      raise ArgumentError, "prefetch_threads must be a positive integer, got: #{prefetch_threads}" unless prefetch_threads.is_a?(Integer) && prefetch_threads > 0
+
       super(partition_count, row_type_data)
       @retreive_proc = retreive_proc
       @prefetch_threads = prefetch_threads
@@ -19,13 +21,11 @@ module RubySnowflake
 
       begin
         data.each_with_index do |_partition, index|
-          # Prefetch the next N partitions (where N = prefetch_threads)
-          # This allows parallel fetching while maintaining memory efficiency
           @prefetch_threads.times do |offset|
             next_index = index + offset + 1
             break if next_index >= data.size
 
-            if data[next_index].nil? # not yet fetched or prefetched
+            if data[next_index].nil?
               data[next_index] = Concurrent::Future.execute(executor: thread_pool) do
                 @retreive_proc.call(next_index)
               end
@@ -50,9 +50,8 @@ module RubySnowflake
           data[index] = :finished
         end
       ensure
-        # Ensure thread pool is properly shut down even if an exception occurs
         thread_pool.shutdown
-        thread_pool.wait_for_termination
+        thread_pool.wait_for_termination(5)
       end
     end
 

--- a/spec/ruby_snowflake/streaming_result_spec.rb
+++ b/spec/ruby_snowflake/streaming_result_spec.rb
@@ -32,6 +32,18 @@ RSpec.describe RubySnowflake::StreamingResult do
         expect(subject.instance_variable_get(:@prefetch_threads)).to eq(4)
       end
     end
+
+    context 'with invalid prefetch_threads' do
+      it 'raises ArgumentError for zero' do
+        expect { described_class.new(partition_count, row_type_data, retrieve_proc, prefetch_threads: 0) }
+          .to raise_error(ArgumentError, /prefetch_threads must be a positive integer/)
+      end
+
+      it 'raises ArgumentError for negative values' do
+        expect { described_class.new(partition_count, row_type_data, retrieve_proc, prefetch_threads: -1) }
+          .to raise_error(ArgumentError, /prefetch_threads must be a positive integer/)
+      end
+    end
   end
 
   describe '#each' do

--- a/spec/ruby_snowflake/streaming_result_spec.rb
+++ b/spec/ruby_snowflake/streaming_result_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RubySnowflake::StreamingResult do
+  let(:partition_count) { 5 }
+  let(:row_type_data) { [{ "name" => "id", "type" => "fixed" }, { "name" => "value", "type" => "text" }] }
+  let(:partitions_data) do
+    [
+      [[1, "first"], [2, "second"]],
+      [[3, "third"], [4, "fourth"]],
+      [[5, "fifth"], [6, "sixth"]],
+      [[7, "seventh"], [8, "eighth"]],
+      [[9, "ninth"], [10, "tenth"]]
+    ]
+  end
+  let(:retrieve_proc) { ->(index) { partitions_data[index] } }
+
+  describe '#initialize' do
+    context 'with default prefetch_threads' do
+      subject { described_class.new(partition_count, row_type_data, retrieve_proc) }
+
+      it 'initializes with 1 prefetch thread by default' do
+        expect(subject.instance_variable_get(:@prefetch_threads)).to eq(1)
+      end
+    end
+
+    context 'with custom prefetch_threads' do
+      subject { described_class.new(partition_count, row_type_data, retrieve_proc, prefetch_threads: 4) }
+
+      it 'initializes with specified prefetch threads' do
+        expect(subject.instance_variable_get(:@prefetch_threads)).to eq(4)
+      end
+    end
+  end
+
+  describe '#each' do
+    subject { described_class.new(partition_count, row_type_data, retrieve_proc, prefetch_threads: prefetch_threads) }
+
+    before do
+      # Populate first partition (as done in StreamingResultStrategy)
+      subject[0] = partitions_data[0]
+    end
+
+    context 'with single thread (backward compatible behavior)' do
+      let(:prefetch_threads) { 1 }
+
+      it 'iterates through all rows correctly' do
+        rows = []
+        subject.each { |row| rows << [row["id"], row["value"]] }
+
+        expect(rows).to eq([
+          [1, "first"], [2, "second"],
+          [3, "third"], [4, "fourth"],
+          [5, "fifth"], [6, "sixth"],
+          [7, "seventh"], [8, "eighth"],
+          [9, "ninth"], [10, "tenth"]
+        ])
+      end
+
+      it 'clears processed partitions to save memory' do
+        rows = []
+        subject.each { |row| rows << row }
+
+        # Check that partitions were cleared (marked as :finished)
+        expect(subject.instance_variable_get(:@data)[0]).to eq(:finished)
+        expect(subject.instance_variable_get(:@data)[1]).to eq(:finished)
+      end
+
+      it 'calls retrieve_proc for each partition' do
+        call_count = 0
+        instrumented_proc = lambda do |index|
+          call_count += 1
+          partitions_data[index]
+        end
+
+        result = described_class.new(partition_count, row_type_data, instrumented_proc, prefetch_threads: 1)
+        result[0] = partitions_data[0]
+
+        result.each { |row| row }
+
+        # Should call for partitions 1-4 (partition 0 was pre-populated)
+        expect(call_count).to eq(4)
+      end
+    end
+
+    context 'with multiple threads' do
+      let(:prefetch_threads) { 3 }
+
+      it 'iterates through all rows correctly' do
+        rows = []
+        subject.each { |row| rows << [row["id"], row["value"]] }
+
+        expect(rows).to eq([
+          [1, "first"], [2, "second"],
+          [3, "third"], [4, "fourth"],
+          [5, "fifth"], [6, "sixth"],
+          [7, "seventh"], [8, "eighth"],
+          [9, "ninth"], [10, "tenth"]
+        ])
+      end
+
+      it 'prefetches multiple partitions in parallel' do
+        # Track concurrent fetches
+        concurrent_fetches = []
+        mutex = Mutex.new
+        instrumented_proc = lambda do |index|
+          mutex.synchronize { concurrent_fetches << index }
+          sleep 0.01 # Simulate network latency
+          partitions_data[index]
+        end
+
+        result = described_class.new(partition_count, row_type_data, instrumented_proc, prefetch_threads: 3)
+        result[0] = partitions_data[0]
+
+        result.each { |row| row }
+
+        # With 3 threads, should prefetch indices 1, 2, 3 before processing them
+        expect(concurrent_fetches).to include(1, 2, 3)
+      end
+
+      it 'properly shuts down thread pool' do
+        thread_pool = nil
+        allow(Concurrent::FixedThreadPool).to receive(:new).and_wrap_original do |method, *args|
+          thread_pool = method.call(*args)
+          thread_pool
+        end
+
+        subject.each { |row| row }
+
+        expect(thread_pool).to be_shutdown
+      end
+    end
+
+    context 'with more threads than partitions' do
+      let(:prefetch_threads) { 10 }
+
+      it 'handles gracefully without errors' do
+        rows = []
+        expect { subject.each { |row| rows << row } }.not_to raise_error
+
+        expect(rows.length).to eq(10)
+      end
+    end
+
+    context 'when returning an enumerator' do
+      let(:prefetch_threads) { 2 }
+
+      it 'returns an enumerator when no block given' do
+        enumerator = subject.each
+
+        expect(enumerator).to be_a(Enumerator)
+        expect(enumerator.to_a.length).to eq(10)
+      end
+    end
+  end
+end

--- a/spec/ruby_snowflake/streaming_result_spec.rb
+++ b/spec/ruby_snowflake/streaming_result_spec.rb
@@ -153,5 +153,29 @@ RSpec.describe RubySnowflake::StreamingResult do
         expect(enumerator.to_a.length).to eq(10)
       end
     end
+
+    context 'when an exception occurs during iteration' do
+      let(:prefetch_threads) { 3 }
+
+      it 'properly shuts down thread pool even on exception' do
+        thread_pool = nil
+        allow(Concurrent::FixedThreadPool).to receive(:new).and_wrap_original do |method, *args|
+          thread_pool = method.call(*args)
+          thread_pool
+        end
+
+        # Raise exception after processing 2 rows
+        count = 0
+        expect do
+          subject.each do |row|
+            count += 1
+            raise StandardError, "Test error" if count == 2
+          end
+        end.to raise_error(StandardError, "Test error")
+
+        # Thread pool should still be shut down
+        expect(thread_pool).to be_shutdown
+      end
+    end
   end
 end


### PR DESCRIPTION
## Overview

This PR dramatically improves `StreamingResult` iteration performance (4-5x faster) through parallel partition prefetching while maintaining memory efficiency.

The idea to use a thread pool came from a performance profiling session at work, while replacing ODBC with the REST API for large Snowflake queries.

While comparing memory usage between the two approaches (ODBC loads everything into memory vs. REST API streaming), I noticed ODBC's iteration was dramatically faster (~0.4s vs ~25s for 300k rows) despite the REST API's superior memory efficiency.

Investigating the `StreamingResult` implementation revealed it hardcoded a single-threaded pool for partition fetching, meaning partitions were fetched sequentially.

Since the gem already had `ThreadedInMemoryStrategy` with configurable thread pools for non-streaming queries and calculated optimal thread counts via number_of_threads_to_use, it seemed natural to apply the same parallel-fetching approach to streaming.

A quick prototype showed 4-5x faster iteration while maintaining the memory benefits, achieving the best of both worlds: ODBC-like speed with streaming's efficiency.

**Important:** I used `Claude Code` to generate most of this PR, but I reviewed the code to ensure I'm not introducing any stupid errors or AI slop. 

## Problem

`StreamingResult` currently hardcodes a single-threaded pool for prefetching partitions:

```ruby
thread_pool = Concurrent::FixedThreadPool.new 1
```

This causes sequential partition fetching, leading to slow iteration for large result sets:
- **300k rows**: ~25-27s iteration time
- Performance limited by network latency per partition fetch
- Underutilizes available connection pool

## Solution

Added configurable `prefetch_threads` parameter that:
1. Enables parallel partition fetching (N partitions at once)
2. Automatically calculates optimal thread count using existing `number_of_threads_to_use` logic
3. Maintains memory efficiency by still clearing processed partitions
4. Ensures proper thread pool shutdown

### Changes

- **`StreamingResult#initialize`**: Added `prefetch_threads:` parameter (default: 1)
- **`StreamingResult#each`**: Updated to prefetch N partitions in parallel
- **`StreamingResultStrategy.result`**: Passes through `prefetch_threads`
- **`Client#retrieve_result_set`**: Uses same thread calculation as non-streaming
- **New test file**: Comprehensive spec with 10 test cases

## Performance Results

Real-world measurements with 300k rows (64 partitions):

| Configuration | Iteration Time | Memory Growth | Total Time | Improvement |
|--------------|----------------|---------------|------------|-------------|
| **Before (1 thread)** | 25-27s | 37 MB | ~28s | baseline |
| **After (4 threads)** | 6-7s | 35 MB | 8s | **4x faster** |
| **After (8 threads)** | 5-6s | 24-36 MB | 7s | **4.5x faster** |
| **ODBC (comparison)** | 0.4s | 75 MB | 6.4s | all in memory |

### Key Metrics
- **Speed**: Now comparable to non-streaming approaches (7s vs 6.4s)
- **Memory**: Still maintains 50-70% memory savings vs ODBC
- **Best of both worlds**: ODBC-like speed with streaming efficiency

## Backward Compatibility

✅ **Fully backward compatible**
- Default `prefetch_threads: 1` maintains existing behavior
- All existing tests pass
- No breaking changes to API

## Implementation Details

### Thread Pool Calculation
Uses the same logic as `ThreadedInMemoryStrategy`:
```ruby
num_threads = number_of_threads_to_use(partition_count)
# Respects max_threads_per_query and thread_scale_factor
```

### Memory Safety
- Old partitions still cleared after iteration (marked as `:finished`)
- Multiple partitions temporarily in memory during prefetch
- Total memory impact: minimal increase, often better than single-threaded

### Resource Management
- Proper thread pool shutdown with `thread_pool.shutdown` and `wait_for_termination`
- Prevents resource leaks

## Testing

Added `spec/ruby_snowflake/streaming_result_spec.rb` with comprehensive coverage:

✅ Single thread backward compatibility
✅ Multi-threaded prefetching behavior
✅ Partition clearing/memory management
✅ Thread pool shutdown
✅ Edge cases (more threads than partitions)
✅ Enumerator support
✅ Concurrent fetch verification

All unit tests pass (22 examples, 0 failures).

## Use Cases

This improvement particularly benefits:
- Large data exports (100k+ rows)
- CSV/report generation from Snowflake
- Data pipelines processing streaming results
- Any application where iteration time is significant

## Configuration

Automatically configured based on partition count and existing settings:
- `max_threads_per_query` (env: `SNOWFLAKE_MAX_THREADS_PER_QUERY`, default: 8)
- `thread_scale_factor` (env: `SNOWFLAKE_THREAD_SCALE_FACTOR`, default: 4)

Formula: `min(partition_count / thread_scale_factor, max_threads_per_query)`

## Real-World Impact

For our prescriber coverage data exports:
- Query returns 300k rows in 64 partitions
- **Before**: 28s total (25s iteration + 3s overhead)
- **After**: 7s total (5s iteration + 2s overhead)
- **Memory**: 35 MB vs 75 MB ODBC (53% savings)

**Result**: Achieves comparable speed to ODBC while using half the memory.

## Questions?

Happy to answer any questions or make adjustments!
