### PR TITLE
[smart-client] Added 401 as a retryable error code and jwt token regeneration logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.4.0)
+    rb_snowflake_client (1.5.0)
       bigdecimal (>= 3.0)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -46,12 +46,12 @@ module RubySnowflake
   class RequestError < Error ; end
   class QueryTimeoutError < Error ;  end
 
-  class SnowflakeQueryExecutionError < Error
+  class SnowflakeQueryExecutionError < StandardError
     attr_reader :request_body
 
-    def initialize(request_body)
+    def initialize(message, request_body)
+      super(message)
       @request_body = request_body
-      super(request_body)
     end
   end
 
@@ -194,7 +194,9 @@ module RubySnowflake
           retrieve_result_set(query_start_time, query, response, streaming, query_timeout)
         end
       rescue StandardError => e
-        raise SnowflakeQueryExecutionError.new(request_body), e.message, e.backtrace
+        error = SnowflakeQueryExecutionError.new(e.message, request_body)
+        error.set_backtrace(e.backtrace)
+        raise error
       end
     end
 

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -75,6 +75,8 @@ module RubySnowflake
     DEFAULT_QUERY_TIMEOUT = 600 # 10 minutes
     # default role to use
     DEFAULT_ROLE = nil
+    # default schema to use
+    DEFAULT_SCHEMA = nil
 
     JSON_PARSE_OPTIONS = { decimal_class: BigDecimal }.freeze
     VALID_RESPONSE_CODES = %w(200 202).freeze
@@ -82,7 +84,7 @@ module RubySnowflake
     POLLING_INTERVAL = 2 # seconds
 
     # can't be set after initialization
-    attr_reader :connection_timeout, :max_connections, :logger, :max_threads_per_query, :thread_scale_factor, :http_retries, :query_timeout, :default_role
+    attr_reader :connection_timeout, :max_connections, :logger, :max_threads_per_query, :thread_scale_factor, :http_retries, :query_timeout, :default_role, :default_schema
 
     def self.from_env(logger: DEFAULT_LOGGER,
                       log_level: DEFAULT_LOG_LEVEL,
@@ -93,7 +95,8 @@ module RubySnowflake
                       thread_scale_factor: env_option("SNOWFLAKE_THREAD_SCALE_FACTOR", DEFAULT_THREAD_SCALE_FACTOR),
                       http_retries: env_option("SNOWFLAKE_HTTP_RETRIES", DEFAULT_HTTP_RETRIES),
                       query_timeout: env_option("SNOWFLAKE_QUERY_TIMEOUT", DEFAULT_QUERY_TIMEOUT),
-                      default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE))
+                      default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE),
+                      default_schema: env_option("SNOWFLAKE_DEFAULT_SCHEMA", DEFAULT_SCHEMA))
       private_key =
         if key = ENV["SNOWFLAKE_PRIVATE_KEY"]
           key
@@ -112,6 +115,7 @@ module RubySnowflake
         ENV["SNOWFLAKE_DEFAULT_WAREHOUSE"],
         ENV["SNOWFLAKE_DEFAULT_DATABASE"],
         default_role: ENV.fetch("SNOWFLAKE_DEFAULT_ROLE", nil),
+        default_schema: ENV.fetch("SNOWFLAKE_DEFAULT_SCHEMA", nil),
         logger: logger,
         log_level: log_level,
         jwt_token_ttl: jwt_token_ttl,
@@ -127,6 +131,7 @@ module RubySnowflake
     def initialize(
       uri, private_key, organization, account, user, default_warehouse, default_database,
       default_role: nil,
+      default_schema: nil,
       logger: DEFAULT_LOGGER,
       log_level: DEFAULT_LOG_LEVEL,
       jwt_token_ttl: DEFAULT_JWT_TOKEN_TTL,
@@ -143,6 +148,7 @@ module RubySnowflake
       @default_warehouse = default_warehouse
       @default_database = default_database
       @default_role = default_role
+      @default_schema = default_schema
 
       # set defaults for config settings
       @logger = logger
@@ -163,6 +169,7 @@ module RubySnowflake
       warehouse ||= @default_warehouse
       database ||= @default_database
       role ||= @default_role
+      schema ||= @default_schema
       query_timeout ||= @query_timeout
 
       response = nil

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -165,7 +165,7 @@ module RubySnowflake
       @_enable_polling_queries = false
     end
 
-    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil, query_name: nil, query_timeout: nil)
+    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil, query_name: nil, query_timeout: nil, parameters: nil)
       warehouse ||= @default_warehouse
       database ||= @default_database
       role ||= @default_role
@@ -188,6 +188,9 @@ module RubySnowflake
               "role" => role,
               "timeout" => query_timeout
             }
+
+            # Add additional parameters if provided
+            request_body["parameters"] = parameters if parameters
 
             response = request_with_auth_and_headers(
               connection,

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -185,11 +185,9 @@ module RubySnowflake
               "database" =>  database&.upcase,
               "statement" => query,
               "bindings" => bindings,
-              "role" => role
+              "role" => role,
+              "timeout" => query_timeout
             }
-
-            # Add server-side timeout if specified
-            request_body["timeout"] = query_timeout.to_i if query_timeout
 
             response = request_with_auth_and_headers(
               connection,

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -243,7 +243,6 @@ module RubySnowflake
         request = request_class.new(uri)
         request["Content-Type"] = "application/json"
         request["Accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@key_pair_jwt_auth_manager.jwt_token}"
         request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
         request.body = body unless body.nil?
 
@@ -251,6 +250,7 @@ module RubySnowflake
                             sleep: lambda {|n| 2**n }, # 1, 2, 4, 8, etc
                             on: [RetryableBadResponseError, OpenSSL::SSL::SSLError],
                             log_method: retryable_log_method) do
+          request["Authorization"] = "Bearer #{@key_pair_jwt_auth_manager.jwt_token}"
           response = nil
           bm = Benchmark.measure { response = connection.request(request) }
           logger.debug { "HTTP Request time: #{bm.real}" }

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -264,9 +264,13 @@ module RubySnowflake
 
         # there are a class of errors we want to retry rather than just giving up
         if retryable_http_response_code?(response.code) && !statement_timeout_error?(response)
+          # 401 indicates auth token rejected - invalidate so retry gets a fresh token
+          if response.code.to_i == 401
+            @key_pair_jwt_auth_manager.invalidate_token
+          end
+
           raise RetryableBadResponseError,
                 "Retryable bad response! Got code: #{response.code}, w/ message #{response.body}"
-
         else # not one we should retry
           raise BadResponseError,
             "Bad response! Got code: #{response.code}, w/ message #{response.body}"
@@ -279,7 +283,7 @@ module RubySnowflake
         # retry (in order): bad request, forbidden (token expired in flight), method not allowed,
         # request timeout, too many requests, anything in the 500 range (504 is fairly common),
         # anything in the 3xx range as those are mostly "redirect" responses
-        [400, 403, 405, 408, 429].include?(code.to_i) || (500..599).include?(code.to_i) ||
+        [400, 401, 403, 405, 408, 429].include?(code.to_i) || (500..599).include?(code.to_i) ||
          (300..399).include?(code.to_i)
       end
 

--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -24,8 +24,10 @@ module RubySnowflake
         return @token unless jwt_token_expired?
 
         @token_semaphore.acquire do
+          # double check in case another thread updated the token
+          return @token unless jwt_token_expired?
           now = Time.now.to_i
-          @token_expires_at = now + @jwt_token_ttl
+          expires_at = now + @jwt_token_ttl
 
           private_key = OpenSSL::PKey.read(@private_key_pem)
 
@@ -33,10 +35,13 @@ module RubySnowflake
             :iss => "#{account_name}.#{@user.upcase}.#{public_key_fingerprint}",
             :sub => "#{account_name}.#{@user.upcase}",
             :iat => now,
-            :exp => @token_expires_at
+            :exp => expires_at
           }
 
           @token = JWT.encode payload, private_key, "RS256"
+          # update the token expires at after the token is updated
+          @token_expires_at = expires_at
+          @token
         end
       end
 

--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -45,28 +45,36 @@ module RubySnowflake
         end
       end
 
+      # Force token regeneration on next call to jwt_token, used when Snowflake rejects the current token
+      def invalidate_token
+        @token_semaphore.acquire do
+          @token_expires_at = Time.now.to_i - 1
+        end
+      end
+
       private
-        def jwt_token_expired?
-          Time.now.to_i > @token_expires_at
+
+      def jwt_token_expired?
+        Time.now.to_i > @token_expires_at
+      end
+
+      def account_name
+        if @organization == nil || @organization == ""
+          @account.upcase
+        else
+          "#{@organization.upcase}-#{@account.upcase}"
         end
+      end
 
-        def account_name
-          if @organization == nil || @organization == ""
-            @account.upcase
-          else
-            "#{@organization.upcase}-#{@account.upcase}"
-          end
-        end
+      def public_key_fingerprint
+        return @public_key_fingerprint unless @public_key_fingerprint.nil?
 
-        def public_key_fingerprint
-          return @public_key_fingerprint unless @public_key_fingerprint.nil?
+        public_key_der = OpenSSL::PKey::RSA.new(@private_key_pem).public_key.to_der
+        digest = OpenSSL::Digest::SHA256.new.digest(public_key_der)
+        fingerprint = Base64.strict_encode64(digest)
 
-          public_key_der = OpenSSL::PKey::RSA.new(@private_key_pem).public_key.to_der
-          digest = OpenSSL::Digest::SHA256.new.digest(public_key_der)
-          fingerprint = Base64.strict_encode64(digest)
-
-          @public_key_fingerprint = "SHA256:#{fingerprint}"
-        end
+        @public_key_fingerprint = "SHA256:#{fingerprint}"
+      end
     end
   end
 end

--- a/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
+++ b/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
@@ -75,4 +75,18 @@ RSpec.describe RubySnowflake::Client::KeyPairJwtAuthManager do
       end
     end
   end
+
+  describe "#invalidate_token" do
+    it "causes the next jwt_token call to regenerate even within token TTL" do
+      first_token = subject.jwt_token
+      first_decoded = JWT.decode(first_token, OpenSSL::PKey::RSA.new(private_key).public_key, true, { algorithm: 'RS256' })[0]
+
+      sleep 1.1 # ensure different iat timestamp
+      subject.invalidate_token
+      second_token = subject.jwt_token
+      second_decoded = JWT.decode(second_token, OpenSSL::PKey::RSA.new(private_key).public_key, true, { algorithm: 'RS256' })[0]
+
+      expect(second_decoded["iat"]).to be > first_decoded["iat"]
+    end
+  end
 end


### PR DESCRIPTION
401 is not in the list of the retry-able http response codes when it should be as snowflake returns 401 and not 403. https://docs.snowflake.com/en/developer-guide/sql-api/reference#response-codes-for-all-operations

Causing the following error in catalog apps:

