### PR TITLE
Add external browser-based authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- External browser authentication via `SNOWFLAKE_AUTHENTICATOR=externalbrowser` with `SNOWFLAKE_SSO_TIMEOUT` and `SNOWFLAKE_SSO_PORT` options
+- v1 Query API support (enables session token authentication)
+
+### Changed
+- `SNOWFLAKE_ORGANIZATION` is now optional (can be omitted or set to nil for some account configurations)
+- `SNOWFLAKE_PRIVATE_KEY`/`SNOWFLAKE_PRIVATE_KEY_PATH` only required for keypair_jwt authentication
 
 ## [1.5.0] - 2025-10-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- External browser authentication via `SNOWFLAKE_AUTHENTICATOR=externalbrowser` with `SNOWFLAKE_SSO_TIMEOUT` and `SNOWFLAKE_SSO_PORT` options
+- v1 Query API support (enables session token authentication)
+
+### Changed
+- `SNOWFLAKE_ORGANIZATION` is now optional for externalbrowser authentication (still required for keypair_jwt)
+- `SNOWFLAKE_PRIVATE_KEY`/`SNOWFLAKE_PRIVATE_KEY_PATH` only required for keypair_jwt authentication
 
 ## [1.6.0] - 2026-04-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ RubySnowflake::Client.from_env
 ```
 Available ENV variables (see below in the config section for details)
 - `SNOWFLAKE_URI`
+- `SNOWFLAKE_AUTHENTICATOR` - Authentication method: "keypair_jwt" (default) or "externalbrowser"
 - `SNOWFLAKE_PRIVATE_KEY_PATH` or `SNOWFLAKE_PRIVATE_KEY`
   - Use either the key or the path. Key takes precedence if both are provided.
+  - Only required for keypair_jwt authentication
 - `SNOWFLAKE_ORGANIZATION`
   - Optional, if you leave it off, the library will authenticate with an account name of only SNOWFLAKE_ACCOUNT
 - `SNOWFLAKE_ACCOUNT`
@@ -62,6 +64,8 @@ Available ENV variables (see below in the config section for details)
 - `SNOWFLAKE_THREAD_SCALE_FACTOR`
 - `SNOWFLAKE_HTTP_RETRIES`
 - `SNOWFLAKE_QUERY_TIMEOUT`
+- `SNOWFLAKE_SSO_TIMEOUT` - Seconds to wait for browser authentication (default: 120), only used with externalbrowser auth
+- `SNOWFLAKE_SSO_PORT` - Port for SSO callback server (default: 0 for random port), only used with externalbrowser auth
 
 ## Make queries
 
@@ -142,6 +146,8 @@ client.query("SELECT * FROM BIGTABLE", query_timeout: 30)
 
 ## Binding parameters
 
+**Note:** Binding parameters are only supported with key pair JWT authentication. If you're using external browser authentication, you'll need to use string interpolation or switch to key pair authentication.
+
 Say we have `BIGTABLE` with a `data` column of a type `VARIANT`.
 
 ```ruby
@@ -214,7 +220,7 @@ end
 # Gotchas
 
 1. Does not yet support multiple statements (work around is to wrap in `BEGIN ... END`)
-2. Only supports key pair authentication
+2. Supports key pair JWT authentication and external browser (SSO/SAML) authentication
 3. It's faster to work directly with the row value and not call to_h if you don't need to
 4. Rows are Enumerable, providing access to methods like `each`, `map`, `select`, `keys`, and `values`
 5. Row column access is case-insensitive and supports string keys, symbol keys, and numeric indices
@@ -272,6 +278,58 @@ client = RubySnowflake::Client.new(
   "some_database",                                      # The name of the database in the context of which the queries will run
 )
 ```
+
+# Using external browser authentication (SSO/SAML)
+
+Use `externalbrowser` when your organization requires SSO/SAML for Snowflake.
+
+**Not suitable for:** Headless environments, automated scripts, or if you need binding parameters.
+
+## How it works
+
+1. Client opens your browser to Snowflake's SSO login page
+2. You authenticate via your identity provider (Okta, Azure AD, etc.)
+3. Session token is cached for 59 minutes
+
+## Setup
+
+Set `SNOWFLAKE_AUTHENTICATOR=externalbrowser`:
+
+```bash
+export SNOWFLAKE_URI="https://yourinstance.region.snowflakecomputing.com"
+export SNOWFLAKE_AUTHENTICATOR="externalbrowser"
+export SNOWFLAKE_ACCOUNT="your-account"
+export SNOWFLAKE_USER="your-username"
+export SNOWFLAKE_DEFAULT_WAREHOUSE="your-warehouse"
+export SNOWFLAKE_DEFAULT_DATABASE="your-database"
+
+# Optional
+export SNOWFLAKE_SSO_TIMEOUT=180  # default: 120 seconds
+export SNOWFLAKE_SSO_PORT=8080    # default: 0 (random port)
+```
+
+Then create your client:
+```ruby
+client = RubySnowflake::Client.from_env
+```
+
+Or specify directly:
+```ruby
+client = RubySnowflake::Client.new(
+  "https://yourinstance.region.snowflakecomputing.com",
+  nil,  # no private key needed
+  nil,
+  "your-account",
+  "your-username",
+  "your-warehouse",
+  "your-database",
+  authenticator: "externalbrowser"
+)
+```
+
+**Limitations:**
+- No binding parameters (use string interpolation)
+- Requires interactive browser access
 
 # Change Log
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ RubySnowflake::Client.from_env
 ```
 Available ENV variables (see below in the config section for details)
 - `SNOWFLAKE_URI`
+- `SNOWFLAKE_AUTHENTICATOR` - Authentication method: "keypair_jwt" (default) or "externalbrowser"
 - `SNOWFLAKE_PRIVATE_KEY_PATH` or `SNOWFLAKE_PRIVATE_KEY`
   - Use either the key or the path. Key takes precedence if both are provided.
+  - Only required for keypair_jwt authentication
 - `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`
-  - Optional, if you are using an encrypted private key
+  - Optional, if you are using an encrypted private key (keypair_jwt only)
 - `SNOWFLAKE_ORGANIZATION`
-  - Optional, if you leave it off, the library will authenticate with an account name of only SNOWFLAKE_ACCOUNT
+  - Required for keypair_jwt; optional for externalbrowser. If you leave it off (externalbrowser), the library authenticates with an account name of only SNOWFLAKE_ACCOUNT
 - `SNOWFLAKE_ACCOUNT`
 - `SNOWFLAKE_USER`
 - `SNOWFLAKE_DEFAULT_WAREHOUSE`
@@ -64,6 +66,8 @@ Available ENV variables (see below in the config section for details)
 - `SNOWFLAKE_THREAD_SCALE_FACTOR`
 - `SNOWFLAKE_HTTP_RETRIES`
 - `SNOWFLAKE_QUERY_TIMEOUT`
+- `SNOWFLAKE_SSO_TIMEOUT` - Seconds to wait for browser authentication (default: 120), only used with externalbrowser auth
+- `SNOWFLAKE_SSO_PORT` - Port for SSO callback server (default: 0 for random port), only used with externalbrowser auth
 
 ## Make queries
 
@@ -144,6 +148,8 @@ client.query("SELECT * FROM BIGTABLE", query_timeout: 30)
 
 ## Binding parameters
 
+**Note:** Binding parameters are only supported with key pair JWT authentication. If you're using external browser authentication, you'll need to use string interpolation or switch to key pair authentication.
+
 Say we have `BIGTABLE` with a `data` column of a type `VARIANT`.
 
 ```ruby
@@ -216,7 +222,7 @@ end
 # Gotchas
 
 1. Does not yet support multiple statements (work around is to wrap in `BEGIN ... END`)
-2. Only supports key pair authentication
+2. Supports key pair JWT authentication and external browser (SSO/SAML) authentication
 3. It's faster to work directly with the row value and not call to_h if you don't need to
 4. Rows are Enumerable, providing access to methods like `each`, `map`, `select`, `keys`, and `values`
 5. Row column access is case-insensitive and supports string keys, symbol keys, and numeric indices
@@ -267,14 +273,104 @@ or alternatively, use the client to verify:
 client = RubySnowflake::Client.new(
   "https://yourinstance.region.snowflakecomputing.com", # insert your URL here
   File.read("secrets/my_key.pem"),                      # path to your private key
-  "private-key-passphrase",                             # your private key passphrase, if it has one (defaults to nil)
   "snowflake-organization",                             # your account name (doesn't match your URL), using nil may be required depending on your snowflake account
   "snowflake-account",                                  # typically your subdomain
   "snowflake-user",                                     # Your snowflake user
   "some_warehouse",                                     # The name of your warehouse to use by default
   "some_database",                                      # The name of the database in the context of which the queries will run
+  private_key_passphrase: "private-key-passphrase",     # your private key passphrase, if it has one (defaults to nil)
 )
 ```
+
+# Using external browser authentication (SSO/SAML)
+
+Use `externalbrowser` when your organization requires SSO/SAML for Snowflake.
+
+**Not suitable for:** Headless environments, automated scripts, or if you need binding parameters.
+
+## How it works
+
+1. Client opens your browser to Snowflake's SSO login page
+2. You authenticate via your identity provider (Okta, Azure AD, etc.)
+3. Session token is cached for 59 minutes
+
+> **API version note:** External browser authentication issues queries against
+> Snowflake's older v1 Query API (`/queries/v1/query-request`) rather than the
+> v2 SQL API (`/api/v2/statements`) used by keypair_jwt. The v1 API authenticates
+> with a session token obtained from the SSO/SAML flow. Query results are returned
+> in the same `RubySnowflake::Result` shape regardless of which API is used, so
+> application code does not need to change between auth methods. Binding
+> parameters are the one feature the v1 path does not support (see Limitations).
+
+## Setup
+
+Set `SNOWFLAKE_AUTHENTICATOR=externalbrowser`:
+
+```bash
+export SNOWFLAKE_URI="https://yourinstance.region.snowflakecomputing.com"
+export SNOWFLAKE_AUTHENTICATOR="externalbrowser"
+export SNOWFLAKE_ACCOUNT="your-account"
+export SNOWFLAKE_USER="your-username"
+export SNOWFLAKE_DEFAULT_WAREHOUSE="your-warehouse"
+export SNOWFLAKE_DEFAULT_DATABASE="your-database"
+
+# Optional
+export SNOWFLAKE_SSO_TIMEOUT=180  # default: 120 seconds
+export SNOWFLAKE_SSO_PORT=8080    # default: 0 (random port)
+```
+
+Then create your client:
+```ruby
+client = RubySnowflake::Client.from_env
+```
+
+Or specify directly:
+```ruby
+client = RubySnowflake::Client.new(
+  "https://yourinstance.region.snowflakecomputing.com",
+  nil,  # no private key needed
+  nil,
+  "your-account",
+  "your-username",
+  "your-warehouse",
+  "your-database",
+  authenticator: "externalbrowser"
+)
+```
+
+**Limitations:**
+- No binding parameters (use string interpolation)
+- Requires interactive browser access
+
+## Testing
+
+The credential-free specs run without a Snowflake account:
+
+```bash
+bundle exec rspec spec/ruby_snowflake/client/                              # auth managers, SSO callback server, browser launcher
+bundle exec rspec spec/ruby_snowflake/client_spec.rb -e "authentication config" -e "v1 API"  # config + v1 routing parity
+```
+
+The remaining `client_spec.rb` examples run live queries and require a real
+Snowflake account. Copy your connection settings into a `.env` file (loaded by
+`dotenv`):
+
+```bash
+SNOWFLAKE_URI="https://yourinstance.region.snowflakecomputing.com"
+SNOWFLAKE_ACCOUNT="your-account"
+SNOWFLAKE_USER="your-username"
+SNOWFLAKE_ORGANIZATION="your-organization"   # required for keypair_jwt
+SNOWFLAKE_PRIVATE_KEY_PATH="secrets/my_key.pem"
+SNOWFLAKE_DEFAULT_WAREHOUSE="your-warehouse"
+SNOWFLAKE_DEFAULT_DATABASE="your-database"
+```
+
+To exercise the external browser path end to end, set
+`SNOWFLAKE_AUTHENTICATOR=externalbrowser` (and omit the private key); the suite
+will open a browser for the SSO flow. Because that flow is interactive, the live
+external browser specs cannot run in headless CI — only the credential-free
+specs above are CI-safe. `client_spec.rb` contains the SQL statements needed to
+create the tables the live specs query.
 
 # Change Log
 

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -10,7 +10,9 @@ require "logger"
 require "net/http"
 require "retryable"
 require "securerandom"
+require "stringio"
 require "uri"
+require "zlib"
 
 begin
   require "active_support"
@@ -19,8 +21,12 @@ rescue LoadError
   # This isn't required
 end
 
+require_relative "client/auth_manager"
 require_relative "client/http_connection_wrapper"
 require_relative "client/key_pair_jwt_auth_manager"
+require_relative "client/browser_launcher"
+require_relative "client/sso_callback_server"
+require_relative "client/external_browser_auth_manager"
 require_relative "client/single_thread_in_memory_strategy"
 require_relative "client/streaming_result_strategy"
 require_relative "client/threaded_in_memory_strategy"
@@ -44,7 +50,10 @@ module RubySnowflake
   class MissingConfig < Error ; end
   class RetryableBadResponseError < Error ; end
   class RequestError < Error ; end
-  class QueryTimeoutError < Error ;  end
+  class QueryTimeoutError < Error ; end
+  class AuthenticationError < Error ; end
+  class SsoTimeoutError < Error ; end
+  class BrowserLaunchError < Error ; end
 
   class Client
     DEFAULT_LOGGER = Logger.new(STDOUT)
@@ -66,6 +75,10 @@ module RubySnowflake
     DEFAULT_QUERY_TIMEOUT = 600 # 10 minutes
     # default role to use
     DEFAULT_ROLE = nil
+    # seconds to wait for SSO callback
+    DEFAULT_SSO_TIMEOUT = 120
+    # SSO callback server port (0 = random available port)
+    DEFAULT_SSO_PORT = 0
 
     JSON_PARSE_OPTIONS = { decimal_class: BigDecimal }.freeze
     VALID_RESPONSE_CODES = %w(200 202).freeze
@@ -84,20 +97,27 @@ module RubySnowflake
                       thread_scale_factor: env_option("SNOWFLAKE_THREAD_SCALE_FACTOR", DEFAULT_THREAD_SCALE_FACTOR),
                       http_retries: env_option("SNOWFLAKE_HTTP_RETRIES", DEFAULT_HTTP_RETRIES),
                       query_timeout: env_option("SNOWFLAKE_QUERY_TIMEOUT", DEFAULT_QUERY_TIMEOUT),
-                      default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE))
-      private_key =
-        if key = ENV["SNOWFLAKE_PRIVATE_KEY"]
-          key
-        elsif path = ENV["SNOWFLAKE_PRIVATE_KEY_PATH"]
-          File.read(path)
-        else
-          raise MissingConfig, "Either ENV['SNOWFLAKE_PRIVATE_KEY'] or ENV['SNOWFLAKE_PRIVATE_KEY_PATH'] must be set"
-        end
+                      default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE),
+                      sso_timeout: env_option("SNOWFLAKE_SSO_TIMEOUT", DEFAULT_SSO_TIMEOUT),
+                      sso_port: env_option("SNOWFLAKE_SSO_PORT", DEFAULT_SSO_PORT))
+      authenticator = ENV.fetch("SNOWFLAKE_AUTHENTICATOR", "keypair_jwt")
+
+      private_key = nil
+      if authenticator.downcase == "keypair_jwt"
+        private_key =
+          if key = ENV["SNOWFLAKE_PRIVATE_KEY"]
+            key
+          elsif path = ENV["SNOWFLAKE_PRIVATE_KEY_PATH"]
+            File.read(path)
+          else
+            raise MissingConfig, "For keypair_jwt auth, either ENV['SNOWFLAKE_PRIVATE_KEY'] or ENV['SNOWFLAKE_PRIVATE_KEY_PATH'] must be set"
+          end
+      end
 
       new(
         ENV.fetch("SNOWFLAKE_URI"),
         private_key,
-        ENV.fetch("SNOWFLAKE_ORGANIZATION"),
+        ENV.fetch("SNOWFLAKE_ORGANIZATION", nil),
         ENV.fetch("SNOWFLAKE_ACCOUNT"),
         ENV.fetch("SNOWFLAKE_USER"),
         ENV["SNOWFLAKE_DEFAULT_WAREHOUSE"],
@@ -112,6 +132,9 @@ module RubySnowflake
         thread_scale_factor: thread_scale_factor,
         http_retries: http_retries,
         query_timeout: query_timeout,
+        authenticator: authenticator,
+        sso_timeout: sso_timeout,
+        sso_port: sso_port
       )
     end
 
@@ -126,11 +149,12 @@ module RubySnowflake
       max_threads_per_query: DEFAULT_MAX_THREADS_PER_QUERY,
       thread_scale_factor: DEFAULT_THREAD_SCALE_FACTOR,
       http_retries: DEFAULT_HTTP_RETRIES,
-      query_timeout: DEFAULT_QUERY_TIMEOUT
+      query_timeout: DEFAULT_QUERY_TIMEOUT,
+      authenticator: "keypair_jwt",
+      sso_timeout: DEFAULT_SSO_TIMEOUT,
+      sso_port: DEFAULT_SSO_PORT
     )
       @base_uri = uri
-      @key_pair_jwt_auth_manager =
-        KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl)
       @default_warehouse = default_warehouse
       @default_database = default_database
       @default_role = default_role
@@ -145,6 +169,30 @@ module RubySnowflake
       @http_retries = http_retries
       @query_timeout = query_timeout
 
+      @auth_manager = if private_key.respond_to?(:apply_auth)
+        private_key
+      else
+        case authenticator.to_s.downcase
+        when "keypair_jwt", "snowflake_jwt"
+          KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl)
+        when "externalbrowser"
+          account_identifier = Client.build_account_identifier(organization, account)
+          @externalbrowser_base_uri = "https://#{account_identifier.downcase}.snowflakecomputing.com"
+          ExternalBrowserAuthManager.new(
+            @externalbrowser_base_uri,
+            account_identifier,
+            user,
+            sso_timeout: sso_timeout,
+            sso_port: sso_port,
+            logger: @logger
+          )
+        else
+          raise MissingConfig.new("Unsupported authenticator: #{authenticator}. Supported: keypair_jwt, externalbrowser")
+        end
+      end
+
+      @key_pair_jwt_auth_manager = @auth_manager if @auth_manager.is_a?(KeyPairJwtAuthManager)
+
       # Do NOT use normally, this exists for tests so we can reliably trigger the polling
       # response workflow from snowflake in tests
       @_enable_polling_queries = false
@@ -156,28 +204,37 @@ module RubySnowflake
       role ||= @default_role
       query_timeout ||= @query_timeout
 
-      with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
-        query_start_time = Time.now.to_i
-        response = nil
-        connection_pool.with do |connection|
-          request_body = {
-            "warehouse" => warehouse&.upcase,
-            "schema" => schema&.upcase,
-            "database" =>  database&.upcase,
-            "statement" => query,
-            "bindings" => bindings,
-            "role" => role,
-            "timeout" => query_timeout
-          }
-
-          response = request_with_auth_and_headers(
-            connection,
-            Net::HTTP::Post,
-            "/api/v2/statements?requestId=#{SecureRandom.uuid}&async=#{@_enable_polling_queries}",
-            request_body.to_json
-          )
+      if @auth_manager.respond_to?(:uses_v1_api?) && @auth_manager.uses_v1_api?
+        if bindings && !bindings.empty?
+          raise ArgumentError, "Bindings are not supported with externalbrowser authentication. Use string interpolation or switch to keypair auth."
         end
-        retrieve_result_set(query_start_time, query, response, streaming, query_timeout)
+        with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
+          query_v1(query, warehouse: warehouse, database: database, schema: schema, role: role, streaming: streaming, query_timeout: query_timeout)
+        end
+      else
+        with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
+          query_start_time = Time.now.to_i
+          response = nil
+          connection_pool.with do |connection|
+            request_body = {
+              "warehouse" => warehouse&.upcase,
+              "schema" => schema&.upcase,
+              "database" =>  database&.upcase,
+              "statement" => query,
+              "bindings" => bindings,
+              "role" => role,
+              "timeout" => query_timeout
+            }
+
+            response = request_with_auth_and_headers(
+              connection,
+              Net::HTTP::Post,
+              "/api/v2/statements?requestId=#{SecureRandom.uuid}&async=#{@_enable_polling_queries}",
+              request_body.to_json
+            )
+          end
+          retrieve_result_set(query_start_time, query, response, streaming, query_timeout)
+        end
       end
     end
 
@@ -191,7 +248,11 @@ module RubySnowflake
     # This method can be used to populate the JWT token used for authentication
     # in tests that require time travel.
     def create_jwt_token
-      @key_pair_jwt_auth_manager.jwt_token
+      if @auth_manager.respond_to?(:jwt_token)
+        @auth_manager.jwt_token
+      else
+        @auth_manager.token
+      end
     end
 
     private_class_method :env_option
@@ -216,8 +277,7 @@ module RubySnowflake
         request = request_class.new(uri)
         request["Content-Type"] = "application/json"
         request["Accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@key_pair_jwt_auth_manager.jwt_token}"
-        request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
+        @auth_manager.apply_auth(request)
         request.body = body unless body.nil?
 
         Retryable.retryable(tries: @http_retries + 1,
@@ -339,6 +399,114 @@ module RubySnowflake
 
       def number_of_threads_to_use(partition_count)
         [[1, (partition_count / @thread_scale_factor.to_f).ceil].max, @max_threads_per_query].min
+      end
+
+      def query_v1(query, warehouse:, database:, schema:, role:, streaming:, query_timeout:)
+        response = nil
+        connection_pool.with do |connection|
+          uri = URI.parse("#{@externalbrowser_base_uri}/queries/v1/query-request?requestId=#{SecureRandom.uuid}")
+          request = Net::HTTP::Post.new(uri)
+          request["Content-Type"] = "application/json"
+          request["Accept"] = "application/snowflake"
+          @auth_manager.apply_auth(request)
+
+          request_body = {
+            "sqlText" => query,
+            "sequenceId" => 1,
+            "querySubmissionTime" => (Time.now.to_f * 1000).to_i
+          }
+          request_body["warehouse"] = warehouse.upcase if warehouse
+          request_body["database"] = database.upcase if database
+          request_body["schema"] = schema.upcase if schema
+          request_body["role"] = role if role
+          request_body["timeout"] = query_timeout if query_timeout
+
+          request.body = request_body.to_json
+
+          Retryable.retryable(tries: @http_retries + 1,
+                              sleep: lambda {|n| 2**n },
+                              on: [RetryableBadResponseError, OpenSSL::SSL::SSLError],
+                              log_method: retryable_log_method) do
+            bm = Benchmark.measure { response = connection.request(request) }
+            logger.debug { "HTTP Request time: #{bm.real}" }
+            raise_on_bad_response(response)
+          end
+        end
+
+        json_body = JSON.parse(response.body, JSON_PARSE_OPTIONS)
+
+        unless json_body["success"]
+          error_msg = json_body["message"] || "Unknown error"
+          error_code = json_body["code"]
+          raise BadResponseError.new("Snowflake query failed (#{error_code}): #{error_msg}")
+        end
+
+        data = json_body["data"]
+        chunks = data["chunks"] || []
+        chunk_headers = data["chunkHeaders"] || {}
+
+        logger.debug { "v1 API response - rowset: #{data["rowset"]&.size || 0} rows, chunks: #{chunks.size}" }
+
+        partition_info = [{ "rowCount" => data["rowset"]&.size || 0 }] +
+                         chunks.map { |c| { "rowCount" => c["rowCount"] } }
+        statement_json = {
+          "resultSetMetaData" => { "rowType" => data["rowtype"], "partitionInfo" => partition_info },
+          "data" => data["rowset"] || []
+        }
+
+        retrieve_proc = ->(index) {
+          chunk = chunks[index - 1]
+          uri = URI.parse(chunk["url"])
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = (uri.scheme == "https")
+
+          request = Net::HTTP::Get.new(uri)
+          chunk_headers.each { |k, v| request[k] = v }
+
+          begin
+            response = http.request(request)
+            unless response.code.start_with?("2")
+              raise BadResponseError.new("S3 chunk fetch failed (#{response.code}): #{response.body[0..500]}")
+            end
+
+            body = response.body
+            is_gzip = response["Content-Encoding"]&.downcase == "gzip" ||
+                      (body.bytesize >= 2 && body.byteslice(0, 2) == "\x1f\x8b".b)
+            if is_gzip
+              body = Zlib::GzipReader.new(StringIO.new(body)).read
+            end
+
+            parsed = JSON.parse("[#{body}]")
+            logger.debug { "Chunk #{index} fetched: #{parsed.size} rows" }
+            parsed
+          rescue => e
+            logger.error("Failed to fetch chunk #{index}: #{e.class} - #{e.message}")
+            raise
+          end
+        }
+
+        if streaming
+          StreamingResultStrategy.result(statement_json, retrieve_proc)
+        elsif chunks.empty?
+          result = Result.new(1, data["rowtype"])
+          result[0] = data["rowset"]
+          result
+        else
+          num_threads = number_of_threads_to_use(partition_info.size)
+          if num_threads == 1
+            SingleThreadInMemoryStrategy.result(statement_json, retrieve_proc)
+          else
+            ThreadedInMemoryStrategy.result(statement_json, retrieve_proc, num_threads)
+          end
+        end
+      end
+
+      def self.build_account_identifier(organization, account)
+        if organization.nil? || organization.empty?
+          account.upcase
+        else
+          "#{organization.upcase}-#{account.upcase}"
+        end
       end
 
       def with_instrumentation(tags, &block)

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -10,7 +10,9 @@ require "logger"
 require "net/http"
 require "retryable"
 require "securerandom"
+require "stringio"
 require "uri"
+require "zlib"
 
 begin
   require "active_support"
@@ -19,8 +21,12 @@ rescue LoadError
   # This isn't required
 end
 
+require_relative "client/auth_manager"
 require_relative "client/http_connection_wrapper"
 require_relative "client/key_pair_jwt_auth_manager"
+require_relative "client/browser_launcher"
+require_relative "client/sso_callback_server"
+require_relative "client/external_browser_auth_manager"
 require_relative "client/single_thread_in_memory_strategy"
 require_relative "client/streaming_result_strategy"
 require_relative "client/threaded_in_memory_strategy"
@@ -44,7 +50,10 @@ module RubySnowflake
   class MissingConfig < Error ; end
   class RetryableBadResponseError < Error ; end
   class RequestError < Error ; end
-  class QueryTimeoutError < Error ;  end
+  class QueryTimeoutError < Error ; end
+  class AuthenticationError < Error ; end
+  class SsoTimeoutError < Error ; end
+  class BrowserLaunchError < Error ; end
 
   class Client
     DEFAULT_LOGGER = Logger.new(STDOUT)
@@ -66,6 +75,10 @@ module RubySnowflake
     DEFAULT_QUERY_TIMEOUT = 600 # 10 minutes
     # default role to use
     DEFAULT_ROLE = nil
+    # seconds to wait for SSO callback
+    DEFAULT_SSO_TIMEOUT = 120
+    # SSO callback server port (0 = random available port)
+    DEFAULT_SSO_PORT = 0
 
     JSON_PARSE_OPTIONS = { decimal_class: BigDecimal }.freeze
     VALID_RESPONSE_CODES = %w(200 202).freeze
@@ -84,25 +97,36 @@ module RubySnowflake
                       thread_scale_factor: env_option("SNOWFLAKE_THREAD_SCALE_FACTOR", DEFAULT_THREAD_SCALE_FACTOR),
                       http_retries: env_option("SNOWFLAKE_HTTP_RETRIES", DEFAULT_HTTP_RETRIES),
                       query_timeout: env_option("SNOWFLAKE_QUERY_TIMEOUT", DEFAULT_QUERY_TIMEOUT),
-                      default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE))
-      private_key =
-        if key = ENV["SNOWFLAKE_PRIVATE_KEY"]
-          key
-        elsif path = ENV["SNOWFLAKE_PRIVATE_KEY_PATH"]
-          File.read(path)
-        else
-          raise MissingConfig, "Either ENV['SNOWFLAKE_PRIVATE_KEY'] or ENV['SNOWFLAKE_PRIVATE_KEY_PATH'] must be set"
-        end
+                      default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE),
+                      sso_timeout: env_option("SNOWFLAKE_SSO_TIMEOUT", DEFAULT_SSO_TIMEOUT),
+                      sso_port: env_option("SNOWFLAKE_SSO_PORT", DEFAULT_SSO_PORT))
+      authenticator = ENV.fetch("SNOWFLAKE_AUTHENTICATOR", "keypair_jwt")
+
+      private_key = nil
+      organization = ENV.fetch("SNOWFLAKE_ORGANIZATION", nil)
+      if authenticator.downcase == "keypair_jwt"
+        private_key =
+          if key = ENV["SNOWFLAKE_PRIVATE_KEY"]
+            key
+          elsif path = ENV["SNOWFLAKE_PRIVATE_KEY_PATH"]
+            File.read(path)
+          else
+            raise MissingConfig, "For keypair_jwt auth, either ENV['SNOWFLAKE_PRIVATE_KEY'] or ENV['SNOWFLAKE_PRIVATE_KEY_PATH'] must be set"
+          end
+        # Organization stays required for keypair_jwt (backwards compatible); it is
+        # optional only for externalbrowser, which derives the account identifier differently.
+        raise MissingConfig, "ENV['SNOWFLAKE_ORGANIZATION'] must be set for keypair_jwt auth" if organization.nil?
+      end
 
       new(
         ENV.fetch("SNOWFLAKE_URI"),
         private_key,
-        ENV["SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"],
-        ENV.fetch("SNOWFLAKE_ORGANIZATION"),
+        organization,
         ENV.fetch("SNOWFLAKE_ACCOUNT"),
         ENV.fetch("SNOWFLAKE_USER"),
         ENV["SNOWFLAKE_DEFAULT_WAREHOUSE"],
         ENV["SNOWFLAKE_DEFAULT_DATABASE"],
+        private_key_passphrase: ENV["SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"],
         default_role: ENV.fetch("SNOWFLAKE_DEFAULT_ROLE", nil),
         logger: logger,
         log_level: log_level,
@@ -113,12 +137,16 @@ module RubySnowflake
         thread_scale_factor: thread_scale_factor,
         http_retries: http_retries,
         query_timeout: query_timeout,
+        authenticator: authenticator,
+        sso_timeout: sso_timeout,
+        sso_port: sso_port
       )
     end
 
     def initialize(
-      uri, private_key, private_key_passphrase = nil, organization, account, user, default_warehouse, default_database,
+      uri, private_key, organization, account, user, default_warehouse, default_database,
       default_role: nil,
+      private_key_passphrase: nil,
       logger: DEFAULT_LOGGER,
       log_level: DEFAULT_LOG_LEVEL,
       jwt_token_ttl: DEFAULT_JWT_TOKEN_TTL,
@@ -127,11 +155,12 @@ module RubySnowflake
       max_threads_per_query: DEFAULT_MAX_THREADS_PER_QUERY,
       thread_scale_factor: DEFAULT_THREAD_SCALE_FACTOR,
       http_retries: DEFAULT_HTTP_RETRIES,
-      query_timeout: DEFAULT_QUERY_TIMEOUT
+      query_timeout: DEFAULT_QUERY_TIMEOUT,
+      authenticator: "keypair_jwt",
+      sso_timeout: DEFAULT_SSO_TIMEOUT,
+      sso_port: DEFAULT_SSO_PORT
     )
       @base_uri = uri
-      @key_pair_jwt_auth_manager =
-        KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase)
       @default_warehouse = default_warehouse
       @default_database = default_database
       @default_role = default_role
@@ -146,6 +175,30 @@ module RubySnowflake
       @http_retries = http_retries
       @query_timeout = query_timeout
 
+      @auth_manager = if private_key.respond_to?(:apply_auth)
+        private_key
+      else
+        case authenticator.to_s.downcase
+        when "keypair_jwt", "snowflake_jwt"
+          KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase)
+        when "externalbrowser"
+          account_identifier = Client.build_account_identifier(organization, account)
+          @externalbrowser_base_uri = "https://#{account_identifier.downcase}.snowflakecomputing.com"
+          ExternalBrowserAuthManager.new(
+            @externalbrowser_base_uri,
+            account_identifier,
+            user,
+            sso_timeout: sso_timeout,
+            sso_port: sso_port,
+            logger: @logger
+          )
+        else
+          raise MissingConfig.new("Unsupported authenticator: #{authenticator}. Supported: keypair_jwt, externalbrowser")
+        end
+      end
+
+      @key_pair_jwt_auth_manager = @auth_manager if @auth_manager.is_a?(KeyPairJwtAuthManager)
+
       # Do NOT use normally, this exists for tests so we can reliably trigger the polling
       # response workflow from snowflake in tests
       @_enable_polling_queries = false
@@ -158,27 +211,14 @@ module RubySnowflake
       query_timeout ||= @query_timeout
 
       with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
-        query_start_time = Time.now.to_i
-        response = nil
-        connection_pool.with do |connection|
-          request_body = {
-            "warehouse" => warehouse&.upcase,
-            "schema" => schema&.upcase,
-            "database" =>  database&.upcase,
-            "statement" => query,
-            "bindings" => bindings,
-            "role" => role,
-            "timeout" => query_timeout
-          }
-
-          response = request_with_auth_and_headers(
-            connection,
-            Net::HTTP::Post,
-            "/api/v2/statements?requestId=#{SecureRandom.uuid}&async=#{@_enable_polling_queries}",
-            request_body.to_json
-          )
+        if uses_v1_api?
+          if bindings && !bindings.empty?
+            raise ArgumentError, "Bindings are not supported with externalbrowser authentication. Use string interpolation or switch to keypair auth."
+          end
+          query_v1(query, warehouse: warehouse, database: database, schema: schema, role: role, streaming: streaming, query_timeout: query_timeout)
+        else
+          query_v2(query, warehouse: warehouse, database: database, schema: schema, bindings: bindings, role: role, streaming: streaming, query_timeout: query_timeout)
         end
-        retrieve_result_set(query_start_time, query, response, streaming, query_timeout)
       end
     end
 
@@ -192,12 +232,21 @@ module RubySnowflake
     # This method can be used to populate the JWT token used for authentication
     # in tests that require time travel.
     def create_jwt_token
-      @key_pair_jwt_auth_manager.jwt_token
+      if @auth_manager.respond_to?(:jwt_token)
+        @auth_manager.jwt_token
+      else
+        @auth_manager.token
+      end
     end
 
     private_class_method :env_option
 
     private
+
+      def uses_v1_api?
+        @auth_manager.respond_to?(:uses_v1_api?) && @auth_manager.uses_v1_api?
+      end
+
       def connection_pool
         @connection_pool ||= ConnectionPool.new(size: @max_connections, timeout: @connection_timeout) do
           HttpConnectionWrapper.new(hostname, port).start
@@ -217,8 +266,7 @@ module RubySnowflake
         request = request_class.new(uri)
         request["Content-Type"] = "application/json"
         request["Accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@key_pair_jwt_auth_manager.jwt_token}"
-        request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
+        @auth_manager.apply_auth(request)
         request.body = body unless body.nil?
 
         Retryable.retryable(tries: @http_retries + 1,
@@ -340,6 +388,142 @@ module RubySnowflake
 
       def number_of_threads_to_use(partition_count)
         [[1, (partition_count / @thread_scale_factor.to_f).ceil].max, @max_threads_per_query].min
+      end
+
+      def query_v2(query, warehouse:, database:, schema:, bindings:, role:, streaming:, query_timeout:)
+        query_start_time = Time.now.to_i
+        response = nil
+        connection_pool.with do |connection|
+          request_body = {
+            "warehouse" => warehouse&.upcase,
+            "schema" => schema&.upcase,
+            "database" =>  database&.upcase,
+            "statement" => query,
+            "bindings" => bindings,
+            "role" => role,
+            "timeout" => query_timeout
+          }
+
+          response = request_with_auth_and_headers(
+            connection,
+            Net::HTTP::Post,
+            "/api/v2/statements?requestId=#{SecureRandom.uuid}&async=#{@_enable_polling_queries}",
+            request_body.to_json
+          )
+        end
+        retrieve_result_set(query_start_time, query, response, streaming, query_timeout)
+      end
+
+      def query_v1(query, warehouse:, database:, schema:, role:, streaming:, query_timeout:)
+        response = nil
+        connection_pool.with do |connection|
+          uri = URI.parse("#{@externalbrowser_base_uri}/queries/v1/query-request?requestId=#{SecureRandom.uuid}")
+          request = Net::HTTP::Post.new(uri)
+          request["Content-Type"] = "application/json"
+          request["Accept"] = "application/snowflake"
+          @auth_manager.apply_auth(request)
+
+          request_body = {
+            "sqlText" => query,
+            "sequenceId" => 1,
+            "querySubmissionTime" => (Time.now.to_f * 1000).to_i
+          }
+          request_body["warehouse"] = warehouse.upcase if warehouse
+          request_body["database"] = database.upcase if database
+          request_body["schema"] = schema.upcase if schema
+          request_body["role"] = role if role
+          request_body["timeout"] = query_timeout if query_timeout
+
+          request.body = request_body.to_json
+
+          Retryable.retryable(tries: @http_retries + 1,
+                              sleep: lambda {|n| 2**n },
+                              on: [RetryableBadResponseError, OpenSSL::SSL::SSLError],
+                              log_method: retryable_log_method) do
+            bm = Benchmark.measure { response = connection.request(request) }
+            logger.debug { "HTTP Request time: #{bm.real}" }
+            raise_on_bad_response(response)
+          end
+        end
+
+        json_body = JSON.parse(response.body, JSON_PARSE_OPTIONS)
+
+        unless json_body["success"]
+          error_msg = json_body["message"] || "Unknown error"
+          error_code = json_body["code"]
+          raise BadResponseError.new("Snowflake query failed (#{error_code}): #{error_msg}")
+        end
+
+        data = json_body["data"]
+        chunks = data["chunks"] || []
+        chunk_headers = data["chunkHeaders"] || {}
+
+        logger.debug { "v1 API response - rowset: #{data["rowset"]&.size || 0} rows, chunks: #{chunks.size}" }
+
+        partition_info = [{ "rowCount" => data["rowset"]&.size || 0 }] +
+                         chunks.map { |c| { "rowCount" => c["rowCount"] } }
+        statement_json = {
+          "resultSetMetaData" => { "rowType" => data["rowtype"], "partitionInfo" => partition_info },
+          "data" => data["rowset"] || []
+        }
+
+        retrieve_proc = ->(index) {
+          chunk = chunks[index - 1]
+          uri = URI.parse(chunk["url"])
+          http = Net::HTTP.new(uri.host, uri.port)
+          http.use_ssl = (uri.scheme == "https")
+
+          request = Net::HTTP::Get.new(uri)
+          chunk_headers.each { |k, v| request[k] = v }
+
+          begin
+            response = Retryable.retryable(tries: @http_retries + 1,
+                                           sleep: lambda {|n| 2**n },
+                                           on: [RetryableBadResponseError, OpenSSL::SSL::SSLError],
+                                           log_method: retryable_log_method) do
+              resp = http.request(request)
+              raise_on_bad_response(resp) unless resp.code.start_with?("2")
+              resp
+            end
+
+            body = response.body
+            is_gzip = response["Content-Encoding"]&.downcase == "gzip" ||
+                      (body.bytesize >= 2 && body.byteslice(0, 2) == "\x1f\x8b".b)
+            if is_gzip
+              body = Zlib::GzipReader.new(StringIO.new(body)).read
+            end
+
+            parsed = JSON.parse("[#{body}]")
+            logger.debug { "Chunk #{index} fetched: #{parsed.size} rows" }
+            parsed
+          rescue => e
+            logger.error("Failed to fetch chunk #{index}: #{e.class} - #{e.message}")
+            raise
+          end
+        }
+
+        if streaming
+          StreamingResultStrategy.result(statement_json, retrieve_proc)
+        elsif chunks.empty?
+          result = Result.new(1, data["rowtype"])
+          result[0] = data["rowset"]
+          result
+        else
+          num_threads = number_of_threads_to_use(partition_info.size)
+          if num_threads == 1
+            SingleThreadInMemoryStrategy.result(statement_json, retrieve_proc)
+          else
+            ThreadedInMemoryStrategy.result(statement_json, retrieve_proc, num_threads)
+          end
+        end
+      end
+
+      def self.build_account_identifier(organization, account)
+        if organization.nil? || organization.empty?
+          account.upcase
+        else
+          "#{organization.upcase}-#{account.upcase}"
+        end
       end
 
       def with_instrumentation(tags, &block)

--- a/lib/ruby_snowflake/client/auth_manager.rb
+++ b/lib/ruby_snowflake/client/auth_manager.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RubySnowflake
+  class Client
+    module AuthManager
+      def apply_auth(request)
+        raise NotImplementedError, "Subclasses must implement #apply_auth"
+      end
+
+      def token
+        raise NotImplementedError, "Subclasses must implement #token"
+      end
+    end
+  end
+end

--- a/lib/ruby_snowflake/client/browser_launcher.rb
+++ b/lib/ruby_snowflake/client/browser_launcher.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rbconfig"
+
+module RubySnowflake
+  class Client
+    class BrowserLauncher
+      def self.open(url)
+        new.open(url)
+      end
+
+      def open(url)
+        case RbConfig::CONFIG["host_os"]
+        when /darwin|mac os/i
+          success = system("open", url, err: File::NULL)
+        when /linux|bsd/i
+          success = system("xdg-open", url, err: File::NULL)
+        when /mswin|mingw|cygwin/i
+          success = system("start", '""', url, err: File::NULL)
+        else
+          raise BrowserLaunchError.new("Unsupported platform for browser launch: #{RbConfig::CONFIG["host_os"]}")
+        end
+
+        raise BrowserLaunchError.new("Failed to open browser with URL: #{url}") unless success
+        true
+      end
+    end
+  end
+end

--- a/lib/ruby_snowflake/client/external_browser_auth_manager.rb
+++ b/lib/ruby_snowflake/client/external_browser_auth_manager.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+require "concurrent"
+require "openssl"
+require_relative "auth_manager"
+require_relative "sso_callback_server"
+require_relative "browser_launcher"
+
+module RubySnowflake
+  class Client
+    class ExternalBrowserAuthManager
+      include AuthManager
+
+      DEFAULT_TOKEN_TTL = 3540 # 59 minutes, same as JWT
+
+      def initialize(uri, account, user, options = {})
+        @base_uri = uri
+        @account = account
+        @user = user
+        @sso_timeout = options.fetch(:sso_timeout, Client::DEFAULT_SSO_TIMEOUT)
+        @sso_port = options.fetch(:sso_port, 0) # 0 = random available port
+        @token_ttl = options.fetch(:token_ttl, DEFAULT_TOKEN_TTL)
+        @logger = options.fetch(:logger, Logger.new($stdout))
+
+        @session_token = nil
+        @token_expires_at = Time.now.to_i - 1 # Force initial auth
+        @token_semaphore = Concurrent::Semaphore.new(1)
+      end
+
+      def apply_auth(request)
+        request["Authorization"] = "Snowflake Token=\"#{token}\""
+      end
+
+      def uses_v1_api?
+        true
+      end
+
+      def token
+        return @session_token unless token_expired?
+
+        @token_semaphore.acquire do
+          return @session_token unless token_expired?
+
+          perform_sso_authentication
+          @session_token
+        end
+      end
+
+      private
+
+      def token_expired?
+        Time.now.to_i > @token_expires_at
+      end
+
+      def perform_sso_authentication
+        callback_server = SsoCallbackServer.new(port: @sso_port, timeout: @sso_timeout)
+        callback_server.start
+
+        sso_response = request_sso_url(callback_server.port)
+        data = sso_response["data"]
+        unless data && data["ssoUrl"] && data["proofKey"]
+          raise AuthenticationError.new("Invalid SSO response: missing required fields")
+        end
+        sso_url = data["ssoUrl"]
+        proof_key = data["proofKey"]
+
+        @logger.info("Opening browser for SSO authentication...")
+
+        BrowserLauncher.open(sso_url)
+
+        @logger.info("Waiting for authentication callback on port #{callback_server.port}...")
+        saml_token = callback_server.wait_for_token
+
+        raise AuthenticationError.new("No SAML token received from SSO callback") unless saml_token
+
+        @session_token = authenticate_with_saml_token(saml_token, proof_key)
+        @token_expires_at = Time.now.to_i + @token_ttl
+
+        @logger.info("SSO authentication successful")
+      rescue Timeout::Error
+        raise SsoTimeoutError.new("SSO authentication timed out after #{@sso_timeout} seconds")
+      ensure
+        callback_server&.shutdown
+      end
+
+      def request_sso_url(callback_port)
+        uri = URI.parse("#{@base_uri}/session/authenticator-request")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Post.new(uri)
+        request["Content-Type"] = "application/json"
+        request["Accept"] = "application/json"
+
+        request.body = {
+          "data" => {
+            "ACCOUNT_NAME" => @account,
+            "LOGIN_NAME" => @user,
+            "AUTHENTICATOR" => "externalbrowser",
+            "BROWSER_MODE_REDIRECT_PORT" => callback_port.to_s
+          }
+        }.to_json
+
+        response = http.request(request)
+
+        unless response.code == "200"
+          raise AuthenticationError.new("Failed to get SSO URL: #{response.code} - #{response.body[0..200]}")
+        end
+
+        JSON.parse(response.body)
+      end
+
+      def authenticate_with_saml_token(saml_token, proof_key)
+        uri = URI.parse("#{@base_uri}/session/v1/login-request")
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = true
+
+        request = Net::HTTP::Post.new(uri)
+        request["Content-Type"] = "application/json"
+        request["Accept"] = "application/json"
+
+        request.body = {
+          "data" => {
+            "ACCOUNT_NAME" => @account,
+            "LOGIN_NAME" => @user,
+            "AUTHENTICATOR" => "externalbrowser",
+            "TOKEN" => saml_token,
+            "PROOF_KEY" => proof_key
+          }
+        }.to_json
+
+        response = http.request(request)
+
+        unless response.code == "200"
+          raise AuthenticationError.new("Failed to authenticate with SAML token: #{response.code} - #{response.body[0..200]}")
+        end
+
+        json = JSON.parse(response.body)
+
+        unless json["success"]
+          raise AuthenticationError.new("Authentication failed: #{json["message"]}")
+        end
+
+        json["data"]["token"]
+      end
+    end
+  end
+end

--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -3,10 +3,13 @@
 require "jwt"
 require "openssl"
 require "concurrent"
+require_relative "auth_manager"
 
 module RubySnowflake
   class Client
     class KeyPairJwtAuthManager
+      include AuthManager
+
       # requires text of a PEM formatted RSA private key
       def initialize(organization, account, user, private_key, jwt_token_ttl)
         @organization = organization
@@ -40,17 +43,20 @@ module RubySnowflake
         end
       end
 
+      alias token jwt_token
+
+      def apply_auth(request)
+        request["Authorization"] = "Bearer #{jwt_token}"
+        request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
+      end
+
       private
         def jwt_token_expired?
           Time.now.to_i > @token_expires_at
         end
 
         def account_name
-          if @organization == nil || @organization == ""
-            @account.upcase
-          else
-            "#{@organization.upcase}-#{@account.upcase}"
-          end
+          Client.build_account_identifier(@organization, @account)
         end
 
         def public_key_fingerprint

--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -3,10 +3,13 @@
 require "jwt"
 require "openssl"
 require "concurrent"
+require_relative "auth_manager"
 
 module RubySnowflake
   class Client
     class KeyPairJwtAuthManager
+      include AuthManager
+
       # requires text of a PEM formatted RSA private key
       def initialize(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase = nil)
         @organization = organization
@@ -40,17 +43,20 @@ module RubySnowflake
         end
       end
 
+      alias token jwt_token
+
+      def apply_auth(request)
+        request["Authorization"] = "Bearer #{jwt_token}"
+        request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
+      end
+
       private
         def jwt_token_expired?
           Time.now.to_i > @token_expires_at
         end
 
         def account_name
-          if @organization == nil || @organization == ""
-            @account.upcase
-          else
-            "#{@organization.upcase}-#{@account.upcase}"
-          end
+          Client.build_account_identifier(@organization, @account)
         end
 
         def public_key_fingerprint

--- a/lib/ruby_snowflake/client/sso_callback_server.rb
+++ b/lib/ruby_snowflake/client/sso_callback_server.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "socket"
+require "uri"
+require "timeout"
+
+module RubySnowflake
+  class Client
+    class SsoCallbackServer
+      SUCCESS_HTML = <<~HTML
+        <html>
+        <head><title>Authentication Successful</title></head>
+        <body>
+        <h1>Authentication Successful</h1>
+        <p>You can close this window and return to your application.</p>
+        </body>
+        </html>
+      HTML
+
+      attr_reader :port
+
+      def initialize(port: 0, timeout: Client::DEFAULT_SSO_TIMEOUT)
+        @port = port
+        @timeout = timeout
+        @server = nil
+      end
+
+      def start
+        @server = TCPServer.new("127.0.0.1", @port)
+        @port = @server.addr[1]
+        self
+      end
+
+      def wait_for_token
+        Timeout.timeout(@timeout) do
+          loop do
+            client = @server.accept
+            begin
+              request_line = client.gets
+              while (line = client.gets) && line != "\r\n"; end
+
+              token = extract_token(request_line)
+              if token
+                client.print("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: #{SUCCESS_HTML.bytesize}\r\n\r\n#{SUCCESS_HTML}")
+                return token
+              else
+                client.print("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n")
+              end
+            ensure
+              client.close rescue nil
+            end
+          end
+        end
+      ensure
+        shutdown
+      end
+
+      def shutdown
+        @server&.close rescue nil
+      end
+
+      private
+
+      def extract_token(request_line)
+        return nil unless request_line
+
+        match = request_line.match(%r{GET /\?token=([^\s&]+)})
+        return nil unless match
+
+        URI.decode_www_form_component(match[1])
+      end
+    end
+  end
+end

--- a/lib/ruby_snowflake/client/sso_callback_server.rb
+++ b/lib/ruby_snowflake/client/sso_callback_server.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "socket"
+require "uri"
+require "timeout"
+
+module RubySnowflake
+  class Client
+    class SsoCallbackServer
+      SUCCESS_HTML = <<~HTML
+        <html>
+        <head><title>Authentication Successful</title></head>
+        <body>
+        <h1>Authentication Successful</h1>
+        <p>You can close this window and return to your application.</p>
+        </body>
+        </html>
+      HTML
+
+      attr_reader :port
+
+      def initialize(port: 0, timeout: Client::DEFAULT_SSO_TIMEOUT)
+        @port = port
+        @timeout = timeout
+        @server = nil
+      end
+
+      def start
+        @server = TCPServer.new("127.0.0.1", @port)
+        @port = @server.addr[1]
+        self
+      end
+
+      def wait_for_token
+        Timeout.timeout(@timeout) do
+          loop do
+            client = @server.accept
+            begin
+              request_line = client.gets
+              while (line = client.gets) && line != "\r\n"; end
+
+              token = extract_token(request_line)
+              if token
+                client.print("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: #{SUCCESS_HTML.bytesize}\r\n\r\n#{SUCCESS_HTML}")
+                return token
+              else
+                client.print("HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n")
+              end
+            ensure
+              client.close rescue nil
+            end
+          end
+        end
+      ensure
+        shutdown
+      end
+
+      def shutdown
+        @server&.close rescue nil
+      end
+
+      private
+
+      def extract_token(request_line)
+        return nil unless request_line
+
+        # Request line is "GET /path?query HTTP/1.1"; Snowflake places the SAML
+        # token in the query string, but its position relative to other params
+        # (e.g. retcode) is not guaranteed, so parse the full query string.
+        match = request_line.match(%r{\AGET\s+(\S+)})
+        return nil unless match
+
+        # A malformed loopback request (port scanner, browser prefetch) can
+        # carry an unparseable path; treat it like any other spurious request
+        # and keep waiting rather than crashing wait_for_token.
+        query = begin
+          URI.parse(match[1]).query
+        rescue URI::InvalidURIError
+          nil
+        end
+        return nil unless query
+
+        param = URI.decode_www_form(query).find { |key, _| key == "token" }
+        param&.last
+      end
+    end
+  end
+end

--- a/lib/ruby_snowflake/client/streaming_result_strategy.rb
+++ b/lib/ruby_snowflake/client/streaming_result_strategy.rb
@@ -11,6 +11,7 @@ module RubySnowflake
           statement_json_body["resultSetMetaData"]["rowType"],
           retreive_proc
         )
+
         result[0] = statement_json_body["data"]
 
         result

--- a/lib/ruby_snowflake/streaming_result.rb
+++ b/lib/ruby_snowflake/streaming_result.rb
@@ -25,7 +25,7 @@ module RubySnowflake
         end
 
         if data[index].is_a? Concurrent::Future
-          data[index] = data[index].value # wait for it to finish
+          data[index] = data[index].value! # wait for it to finish, raises on exception
         end
 
         data[index].each do |row|

--- a/spec/ruby_snowflake/client/external_browser_auth_manager_spec.rb
+++ b/spec/ruby_snowflake/client/external_browser_auth_manager_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubySnowflake::Client::ExternalBrowserAuthManager do
+  let(:base_uri) { "https://test.snowflakecomputing.com" }
+  let(:account_identifier) { "TEST_ACCOUNT" }
+  let(:user) { "test_user" }
+  let(:sso_timeout) { 5 }
+
+  subject { described_class.new(base_uri, account_identifier, user, sso_timeout: sso_timeout) }
+
+  describe "#uses_v1_api?" do
+    it "returns true" do
+      expect(subject.uses_v1_api?).to eq(true)
+    end
+  end
+
+  describe "#apply_auth" do
+    it "uses correct Snowflake Token authorization header format" do
+      # Mock the token without triggering browser auth
+      subject.instance_variable_set(:@session_token, "mock_token_123")
+      subject.instance_variable_set(:@token_expires_at, Time.now.to_i + 3600)
+
+      request = Net::HTTP::Get.new(URI("https://test.com"))
+      subject.apply_auth(request)
+
+      auth_header = request["Authorization"]
+      expect(auth_header).to eq('Snowflake Token="mock_token_123"')
+    end
+  end
+end

--- a/spec/ruby_snowflake/client/sso_callback_server_spec.rb
+++ b/spec/ruby_snowflake/client/sso_callback_server_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubySnowflake::Client::SsoCallbackServer do
+  describe "#start and #shutdown" do
+    it "binds to localhost on a random port" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+
+      expect(server.port).to be > 0
+      expect(server.port).to be < 65536
+
+      server.shutdown
+    end
+  end
+
+  describe "#wait_for_token" do
+    it "extracts token from a valid request" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      socket = TCPSocket.new("127.0.0.1", port)
+      socket.print("GET /?token=test_token_123 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      response = socket.read
+      socket.close
+
+      token = token_thread.value
+      expect(token).to eq("test_token_123")
+      expect(response).to include("200 OK")
+    end
+
+    it "handles favicon request gracefully without breaking token wait" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      # Send favicon request first (should get 404, server keeps waiting)
+      favicon_socket = TCPSocket.new("127.0.0.1", port)
+      favicon_socket.print("GET /favicon.ico HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      favicon_response = favicon_socket.read
+      favicon_socket.close
+
+      expect(favicon_response).to include("404")
+
+      # Now send real token request
+      token_socket = TCPSocket.new("127.0.0.1", port)
+      token_socket.print("GET /?token=real_token HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      token_response = token_socket.read
+      token_socket.close
+
+      token = token_thread.value
+      expect(token).to eq("real_token")
+      expect(token_response).to include("200 OK")
+    end
+
+    it "handles multiple spurious requests before receiving valid token" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      # Send multiple spurious requests
+      3.times do |i|
+        socket = TCPSocket.new("127.0.0.1", port)
+        socket.print("GET /spurious#{i} HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        response = socket.read
+        socket.close
+        expect(response).to include("404")
+      end
+
+      # Finally send the real token
+      socket = TCPSocket.new("127.0.0.1", port)
+      socket.print("GET /?token=final_token HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      socket.read
+      socket.close
+
+      token = token_thread.value
+      expect(token).to eq("final_token")
+    end
+
+    it "times out appropriately when no token is received" do
+      server = described_class.new(port: 0, timeout: 1)
+      server.start
+
+      start_time = Time.now
+      expect { server.wait_for_token }.to raise_error(Timeout::Error)
+
+      elapsed = Time.now - start_time
+      expect(elapsed).to be_within(0.5).of(1.0)
+    end
+  end
+end

--- a/spec/ruby_snowflake/client/sso_callback_server_spec.rb
+++ b/spec/ruby_snowflake/client/sso_callback_server_spec.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe RubySnowflake::Client::SsoCallbackServer do
+  describe "#start and #shutdown" do
+    it "binds to localhost on a random port" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+
+      expect(server.port).to be > 0
+      expect(server.port).to be < 65536
+
+      server.shutdown
+    end
+  end
+
+  describe "#wait_for_token" do
+    it "extracts token from a valid request" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      socket = TCPSocket.new("127.0.0.1", port)
+      socket.print("GET /?token=test_token_123 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      response = socket.read
+      socket.close
+
+      token = token_thread.value
+      expect(token).to eq("test_token_123")
+      expect(response).to include("200 OK")
+    end
+
+    it "extracts token when it is not the first query parameter" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      socket = TCPSocket.new("127.0.0.1", port)
+      socket.print("GET /?retcode=0&token=reordered_token HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      response = socket.read
+      socket.close
+
+      token = token_thread.value
+      expect(token).to eq("reordered_token")
+      expect(response).to include("200 OK")
+    end
+
+    it "url-decodes a percent-encoded token" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      socket = TCPSocket.new("127.0.0.1", port)
+      socket.print("GET /?token=tok%2Bwith%2Fchars HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      socket.read
+      socket.close
+
+      expect(token_thread.value).to eq("tok+with/chars")
+    end
+
+    it "handles favicon request gracefully without breaking token wait" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      # Send favicon request first (should get 404, server keeps waiting)
+      favicon_socket = TCPSocket.new("127.0.0.1", port)
+      favicon_socket.print("GET /favicon.ico HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      favicon_response = favicon_socket.read
+      favicon_socket.close
+
+      expect(favicon_response).to include("404")
+
+      # Now send real token request
+      token_socket = TCPSocket.new("127.0.0.1", port)
+      token_socket.print("GET /?token=real_token HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      token_response = token_socket.read
+      token_socket.close
+
+      token = token_thread.value
+      expect(token).to eq("real_token")
+      expect(token_response).to include("200 OK")
+    end
+
+    it "handles multiple spurious requests before receiving valid token" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      # Send multiple spurious requests
+      3.times do |i|
+        socket = TCPSocket.new("127.0.0.1", port)
+        socket.print("GET /spurious#{i} HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        response = socket.read
+        socket.close
+        expect(response).to include("404")
+      end
+
+      # Finally send the real token
+      socket = TCPSocket.new("127.0.0.1", port)
+      socket.print("GET /?token=final_token HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      socket.read
+      socket.close
+
+      token = token_thread.value
+      expect(token).to eq("final_token")
+    end
+
+    it "handles a malformed request line gracefully without breaking token wait" do
+      server = described_class.new(port: 0, timeout: 5)
+      server.start
+      port = server.port
+
+      token_thread = Thread.new { server.wait_for_token }
+      sleep 0.1
+
+      # An unparseable path (invalid percent-encoding) must not crash the
+      # wait loop; the server should 404 and keep waiting like any spurious request.
+      malformed_socket = TCPSocket.new("127.0.0.1", port)
+      malformed_socket.print("GET /%zz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      malformed_response = malformed_socket.read
+      malformed_socket.close
+
+      expect(malformed_response).to include("404")
+
+      token_socket = TCPSocket.new("127.0.0.1", port)
+      token_socket.print("GET /?token=after_malformed HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      token_response = token_socket.read
+      token_socket.close
+
+      token = token_thread.value
+      expect(token).to eq("after_malformed")
+      expect(token_response).to include("200 OK")
+    end
+
+    it "times out appropriately when no token is received" do
+      server = described_class.new(port: 0, timeout: 1)
+      server.start
+
+      start_time = Time.now
+      expect { server.wait_for_token }.to raise_error(Timeout::Error)
+
+      elapsed = Time.now - start_time
+      expect(elapsed).to be_within(0.5).of(1.0)
+    end
+  end
+end

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -576,6 +576,23 @@ RSpec.describe RubySnowflake::Client do
     end
   end
 
+  describe ".build_account_identifier" do
+    it "formats with organization and account" do
+      result = described_class.build_account_identifier("myorg", "myacct")
+      expect(result).to eq("MYORG-MYACCT")
+    end
+
+    it "formats with only account when organization is nil" do
+      result = described_class.build_account_identifier(nil, "myacct")
+      expect(result).to eq("MYACCT")
+    end
+
+    it "formats with only account when organization is empty string" do
+      result = described_class.build_account_identifier("", "myacct")
+      expect(result).to eq("MYACCT")
+    end
+  end
+
   describe RubySnowflake::Error do
     it "initializes with error details" do
       error = described_class.new("Test error message")

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -576,6 +576,112 @@ RSpec.describe RubySnowflake::Client do
     end
   end
 
+  describe ".build_account_identifier" do
+    it "formats with organization and account" do
+      result = described_class.build_account_identifier("myorg", "myacct")
+      expect(result).to eq("MYORG-MYACCT")
+    end
+
+    it "formats with only account when organization is nil" do
+      result = described_class.build_account_identifier(nil, "myacct")
+      expect(result).to eq("MYACCT")
+    end
+
+    it "formats with only account when organization is empty string" do
+      result = described_class.build_account_identifier("", "myacct")
+      expect(result).to eq("MYACCT")
+    end
+  end
+
+  describe ".from_env authentication config" do
+    around do |example|
+      old_env = ENV.to_h
+      ENV.clear
+      ENV["SNOWFLAKE_URI"] = "https://acct.snowflakecomputing.com"
+      ENV["SNOWFLAKE_ACCOUNT"] = "acct"
+      ENV["SNOWFLAKE_USER"] = "user"
+      example.run
+    ensure
+      ENV.replace(old_env)
+    end
+
+    context "with keypair_jwt authentication" do
+      before do
+        ENV["SNOWFLAKE_AUTHENTICATOR"] = "keypair_jwt"
+        ENV["SNOWFLAKE_PRIVATE_KEY"] = OpenSSL::PKey::RSA.new(2048).to_pem
+      end
+
+      it "raises when SNOWFLAKE_ORGANIZATION is not set" do
+        expect { described_class.from_env }.to raise_error(RubySnowflake::MissingConfig, /SNOWFLAKE_ORGANIZATION/)
+      end
+
+      it "builds a client when SNOWFLAKE_ORGANIZATION is set" do
+        ENV["SNOWFLAKE_ORGANIZATION"] = "org"
+        expect(described_class.from_env).to be_a(described_class)
+      end
+    end
+
+    context "with externalbrowser authentication" do
+      before { ENV["SNOWFLAKE_AUTHENTICATOR"] = "externalbrowser" }
+
+      it "builds a client without SNOWFLAKE_ORGANIZATION" do
+        expect(described_class.from_env).to be_a(described_class)
+      end
+
+      it "builds a client without a private key" do
+        expect(described_class.from_env).to be_a(described_class)
+      end
+    end
+  end
+
+  describe "external browser (v1 API) query routing" do
+    subject(:client) do
+      described_class.new(
+        "https://acct.snowflakecomputing.com", nil, nil, "acct", "user", nil, nil,
+        authenticator: "externalbrowser"
+      )
+    end
+
+    before do
+      auth_manager = client.instance_variable_get(:@auth_manager)
+      allow(auth_manager).to receive(:apply_auth)
+    end
+
+    def stub_v1_response(body)
+      response = Net::HTTPSuccess.new("1.1", "200", "OK")
+      allow(response).to receive(:code).and_return("200")
+      allow(response).to receive(:body).and_return(body.to_json)
+      allow(response).to receive(:[]).and_return(nil)
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_return(response)
+    end
+
+    it "returns a Result for a single-partition query" do
+      stub_v1_response(
+        success: true,
+        data: {
+          rowtype: [{ "name" => "1", "type" => "FIXED" }],
+          rowset: [[1]],
+          chunks: []
+        }
+      )
+
+      result = client.query("SELECT 1")
+      expect(result).to be_a(RubySnowflake::Result)
+      expect(result.get_all_rows).to eq([{ "1" => 1 }])
+    end
+
+    it "raises a BadResponseError when the v1 response is unsuccessful" do
+      stub_v1_response(success: false, message: "boom", code: "1234")
+
+      expect { client.query("SELECT 1") }.to raise_error(RubySnowflake::BadResponseError, /boom/)
+    end
+
+    it "rejects bindings because v1 does not support them" do
+      expect { client.query("SELECT ?", bindings: { "1" => { type: "TEXT", value: "x" } }) }
+        .to raise_error(ArgumentError, /Bindings are not supported/)
+    end
+  end
+
   describe RubySnowflake::Error do
     it "initializes with error details" do
       error = described_class.new("Test error message")


### PR DESCRIPTION
This PR adds external browser (SSO/SAML) authentication support. Previously, the gem only supported key pair JWT authentication, which doesn't work for organizations that require browser-based SSO login through identity providers like Okta or Azure AD.

When a user sets `SNOWFLAKE_AUTHENTICATOR=externalbrowser`, the client opens their default browser to complete SSO authentication, receives a session token, and caches it for the 59-minute session window. The goal is to mirror the `externalbrowser` auth method supported in the Python client for Snowflake

Implementation:
- Added v1 Query API support (required for session token authentication)
- Added SSO callback server and browser launcher with cross-platform support
- Made `SNOWFLAKE_ORGANIZATION` optional to support varied account configurations
- Bindings are not supported with externalbrowser auth (raises `ArgumentError`)

I added unit tests for this functionality, and also manually tested the browser sign in flow locally (we use Okta for SSO at Block) on my Mac. I still need to properly test the browser flow end-to-end on Linux and Windows (WSL) systems

Resolves #78