### PR TITLE
Fix Ruby 3.0 SyntaxError in instrumentation hash

### DIFF
--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -156,7 +156,12 @@ module RubySnowflake
       role ||= @default_role
       query_timeout ||= @query_timeout
 
-      with_instrumentation({ database:, schema:, warehouse:, query_name: }) do
+      with_instrumentation({
+        database: database,
+        schema: schema,
+        warehouse: warehouse,
+        query_name: query_name
+      }) do
         query_start_time = Time.now.to_i
         response = nil
         connection_pool.with do |connection|


### PR DESCRIPTION
## Summary

`rb_snowflake_client 1.5.0` uses `Ruby 3.1+` hash value omission syntax `({ database:, schema:, ... })`. `Ruby 3.0` fails to parse this, raising a `SyntaxError` at load time. This change expands the hash to explicit `key/value` pairs, preserving behavior while restoring `Ruby 3.0` compatibility.

## Repro

  1. Use Ruby 3.0.x.
  2. Install rb_snowflake_client 1.5.0.
  3. Require the gem or call RubySnowflake::Client#query.
  4. Observe: `SyntaxError: unexpected ',' ... with_instrumentation({ database:, schema:, warehouse:, query_name: })`

## Fix
  Expand the hash literal to explicit values:

```ruby
  with_instrumentation({
    database: database,
    schema: schema,
    warehouse: warehouse,
    query_name: query_name
  })
  ```

No functional change; syntax only.