### PR TITLE
Add session parameters support to query method

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,22 @@ client.query(query, bindings: bindings)
 
 For additional information about binding parameters refer to snowflake documentation: https://docs.snowflake.com/en/developer-guide/sql-api/submitting-requests#using-bind-variables-in-a-statement
 
+## Session parameters
+
+You can set Snowflake session parameters on a per-query basis by passing a hash to the `parameters` option. These parameters affect query behavior and can be used to set things like query tags, timezones, and other session-level settings.
+
+```ruby
+client.query(
+  "SELECT * FROM BIGTABLE",
+  parameters: {
+    "QUERY_TAG" => "my_custom_tag",
+    "TIMEZONE" => "America/Los_Angeles"
+  }
+)
+```
+
+For a full list of available parameters, refer to the Snowflake documentation: https://docs.snowflake.com/en/developer-guide/sql-api/reference
+
 ## Instrumentation
 
 If ActiveSupport is available, this library additionally emits [notification events](https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html) around queries. You can subscribe to those to track timing, query counts, etc.

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -150,7 +150,7 @@ module RubySnowflake
       @_enable_polling_queries = false
     end
 
-    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil, query_name: nil, query_timeout: nil)
+    def query(query, warehouse: nil, streaming: false, database: nil, schema: nil, bindings: nil, role: nil, query_name: nil, query_timeout: nil, parameters: nil)
       warehouse ||= @default_warehouse
       database ||= @default_database
       role ||= @default_role
@@ -167,7 +167,8 @@ module RubySnowflake
             "statement" => query,
             "bindings" => bindings,
             "role" => role,
-            "timeout" => query_timeout
+            "timeout" => query_timeout,
+            "parameters" => parameters
           }
 
           response = request_with_auth_and_headers(

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -160,6 +160,58 @@ RSpec.describe RubySnowflake::Client do
       end
     end
 
+    context "with parameters" do
+      let(:query) { "SELECT 1" }
+
+      it "sends parameters in the request body" do
+        allow_any_instance_of(Net::HTTP).to receive(:request) do |instance, request|
+          request_body = JSON.parse(request.body)
+          expect(request_body["parameters"]).to eq({
+            "QUERY_TAG" => "my_custom_tag",
+            "TIMEZONE" => "America/Los_Angeles"
+          })
+
+          response = Net::HTTPSuccess.new("1.1", "200", "OK")
+          allow(response).to receive(:body).and_return({
+            statementHandle: "test-handle",
+            resultSetMetaData: {
+              partitionInfo: [{}],
+              rowType: [{ name: "1", type: "FIXED" }]
+            },
+            data: [[1]]
+          }.to_json)
+          response
+        end
+
+        result = client.query(query, parameters: {
+          "QUERY_TAG" => "my_custom_tag",
+          "TIMEZONE" => "America/Los_Angeles"
+        })
+        expect(result).to be_a(RubySnowflake::Result)
+      end
+
+      it "does not include parameters when nil" do
+        allow_any_instance_of(Net::HTTP).to receive(:request) do |instance, request|
+          request_body = JSON.parse(request.body)
+          expect(request_body["parameters"]).to be_nil
+
+          response = Net::HTTPSuccess.new("1.1", "200", "OK")
+          allow(response).to receive(:body).and_return({
+            statementHandle: "test-handle",
+            resultSetMetaData: {
+              partitionInfo: [{}],
+              rowType: [{ name: "1", type: "FIXED" }]
+            },
+            data: [[1]]
+          }.to_json)
+          response
+        end
+
+        result = client.query(query)
+        expect(result).to be_a(RubySnowflake::Result)
+      end
+    end
+
     context "when the query errors" do
       let(:query) { "INVALID QUERY;" }
       it "should raise an exception" do


### PR DESCRIPTION
  ## Summary

  Adds a new `parameters` option to `client.query()` that allows setting Snowflake session parameters on a per-query basis. Parameters are passed directly to the Snowflake SQL API without
   modification.

  ## Use Cases

  Common use cases include:
  - Setting `QUERY_TAG` for query tracking and monitoring
  - Setting `TIMEZONE` for date/time operations
  - Configuring other session-level settings per query

  ## Example Usage

  ```ruby
  client.query(
    "SELECT * FROM table",
    parameters: {
      "QUERY_TAG" => "my_custom_tag",
      "TIMEZONE" => "America/Los_Angeles"
    }
  )
```

  Changes

  - Added parameters keyword argument to query method signature
  - Updated request body to include parameters field
  - Added comprehensive test coverage
  - Updated README with usage examples and documentation

  Testing

  ✅ All new tests pass
  ✅ Parameters correctly passed to Snowflake API
  ✅ Nil parameters handled gracefully
  ✅ No breaking changes to existing functionality

  ---
  Reference: https://docs.snowflake.com/en/developer-guide/sql-api/reference