### PR TITLE
Add ability to pass in encrypted key passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Available ENV variables (see below in the config section for details)
 - `SNOWFLAKE_URI`
 - `SNOWFLAKE_PRIVATE_KEY_PATH` or `SNOWFLAKE_PRIVATE_KEY`
   - Use either the key or the path. Key takes precedence if both are provided.
+- `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`
+  - Optional, if you are using an encrypted private key
 - `SNOWFLAKE_ORGANIZATION`
   - Optional, if you leave it off, the library will authenticate with an account name of only SNOWFLAKE_ACCOUNT
 - `SNOWFLAKE_ACCOUNT`
@@ -265,6 +267,7 @@ or alternatively, use the client to verify:
 client = RubySnowflake::Client.new(
   "https://yourinstance.region.snowflakecomputing.com", # insert your URL here
   File.read("secrets/my_key.pem"),                      # path to your private key
+  "private-key-passphrase",                             # your private key passphrase, if it has one (defaults to nil)
   "snowflake-organization",                             # your account name (doesn't match your URL), using nil may be required depending on your snowflake account
   "snowflake-account",                                  # typically your subdomain
   "snowflake-user",                                     # Your snowflake user

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -97,6 +97,7 @@ module RubySnowflake
       new(
         ENV.fetch("SNOWFLAKE_URI"),
         private_key,
+        ENV["SNOWFLAKE_PRIVATE_KEY_PASSPHRASE"],
         ENV.fetch("SNOWFLAKE_ORGANIZATION"),
         ENV.fetch("SNOWFLAKE_ACCOUNT"),
         ENV.fetch("SNOWFLAKE_USER"),
@@ -116,7 +117,7 @@ module RubySnowflake
     end
 
     def initialize(
-      uri, private_key, organization, account, user, default_warehouse, default_database,
+      uri, private_key, private_key_passphrase = nil, organization, account, user, default_warehouse, default_database,
       default_role: nil,
       logger: DEFAULT_LOGGER,
       log_level: DEFAULT_LOG_LEVEL,
@@ -130,7 +131,7 @@ module RubySnowflake
     )
       @base_uri = uri
       @key_pair_jwt_auth_manager =
-        KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl)
+        KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase)
       @default_warehouse = default_warehouse
       @default_database = default_database
       @default_role = default_role

--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -8,12 +8,13 @@ module RubySnowflake
   class Client
     class KeyPairJwtAuthManager
       # requires text of a PEM formatted RSA private key
-      def initialize(organization, account, user, private_key, jwt_token_ttl)
+      def initialize(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase = nil)
         @organization = organization
         @account = account
         @user = user
         @private_key_pem = private_key
         @jwt_token_ttl = jwt_token_ttl
+        @private_key_passphrase = private_key_passphrase
 
         # start with an expired value to force creation
         @token_expires_at = Time.now.to_i - 1
@@ -26,8 +27,7 @@ module RubySnowflake
         @token_semaphore.acquire do
           now = Time.now.to_i
           @token_expires_at = now + @jwt_token_ttl
-
-          private_key = OpenSSL::PKey.read(@private_key_pem)
+          private_key = OpenSSL::PKey.read(@private_key_pem, @private_key_passphrase)
 
           payload = {
             :iss => "#{account_name}.#{@user.upcase}.#{public_key_fingerprint}",
@@ -56,7 +56,7 @@ module RubySnowflake
         def public_key_fingerprint
           return @public_key_fingerprint unless @public_key_fingerprint.nil?
 
-          public_key_der = OpenSSL::PKey::RSA.new(@private_key_pem).public_key.to_der
+          public_key_der = OpenSSL::PKey::RSA.new(@private_key_pem, @private_key_passphrase).public_key.to_der
           digest = OpenSSL::Digest::SHA256.new.digest(public_key_der)
           fingerprint = Base64.strict_encode64(digest)
 

--- a/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
+++ b/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
@@ -6,8 +6,9 @@ RSpec.describe RubySnowflake::Client::KeyPairJwtAuthManager do
   let(:user) { "user" }
   let(:private_key) { OpenSSL::PKey::RSA.new(2048).to_pem }
   let(:jwt_token_ttl) { 3600 }
+  let(:private_key_passphrase) { nil }
   
-  subject { described_class.new(organization, account, user, private_key, jwt_token_ttl) }
+  subject { described_class.new(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase) }
 
   describe "#jwt_token" do
     context "when creating a JWT token" do
@@ -34,6 +35,31 @@ RSpec.describe RubySnowflake::Client::KeyPairJwtAuthManager do
         
         # Expect the token to expire in approximately jwt_token_ttl seconds
         expect(decoded_token["exp"] - now).to be_within(5).of(jwt_token_ttl)
+      end
+    end
+
+    context "when the private key is encrypted" do
+      let(:private_key) do
+        key = OpenSSL::PKey::RSA.new(2048)
+        cipher = OpenSSL::Cipher.new("AES-128-CBC")
+        key.to_pem(cipher, "password")
+      end
+      let(:private_key_passphrase) { "password" }
+
+      it "generates a valid token" do
+        expect(subject.jwt_token).to be_a(String)
+      end
+
+      it "generates a token with the correct claims" do
+        # Use the JWT gem to decode the token
+        token = subject.jwt_token
+        decoded_token = JWT.decode(token, OpenSSL::PKey::RSA.new(private_key, private_key_passphrase).public_key, true, { algorithm: 'RS256' })[0]
+
+        expect(decoded_token["iss"]).to include(account.upcase)
+        expect(decoded_token["iss"]).to include(user.upcase)
+        expect(decoded_token["sub"]).to eq("#{account.upcase}.#{user.upcase}")
+        expect(decoded_token["iat"]).to be_a(Integer)
+        expect(decoded_token["exp"]).to be_a(Integer)
       end
     end
   end


### PR DESCRIPTION
What?
Adds the ability to pass in a passphrase to decrypt an encrypted RSA key 

Why?
It's a pretty common thing, for security purposes, to work with encrypted keys.

My organization tends towards encrypted keys, and we want to replace the client we built in house with this one, and we need this to be available.