### PR TITLE
chore(deps): bump activesupport to patch CVEs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "bundler"
 gem "rake"
 
 group :development, :test do
-  gem "activesupport"
+  gem "activesupport", "~> 8.0.4", ">= 8.0.4.1"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.4.0)
+    rb_snowflake_client (1.5.0)
       bigdecimal (>= 3.0)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)
@@ -13,7 +13,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.0.3)
+    activesupport (8.0.5)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -27,23 +27,26 @@ GEM
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
     base64 (0.3.0)
-    benchmark (0.4.1)
-    bigdecimal (3.3.1)
+    benchmark (0.5.0)
+    bigdecimal (4.1.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.4)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
     drb (2.2.3)
-    i18n (1.14.7)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.15.1)
     jwt (3.1.2)
       base64
     logger (1.7.0)
     method_source (1.1.0)
-    minitest (5.26.0)
+    minitest (6.0.3)
+      drb (~> 2.0)
+      prism (~> 1.5)
     parallel (1.27.0)
+    prism (1.9.0)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -65,14 +68,14 @@ GEM
     securerandom (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uri (1.0.4)
+    uri (1.1.1)
 
 PLATFORMS
   arm64-darwin-22
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (~> 8.0.4, >= 8.0.4.1)
   bundler
   parallel
   pry
@@ -81,4 +84,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.5.10
+  4.0.3


### PR DESCRIPTION
Bumps `activesupport` from 8.0.3 to 8.0.5 to close 3 Dependabot alerts (all medium).
