### PR TITLE
Add bearer-token (PAT / OAuth) authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `access_token:` option on `Client.new` / `Client.from_env` (`SNOWFLAKE_ACCESS_TOKEN`)
+  to authenticate with a pre-issued **bearer token** — e.g. a Programmatic Access Token
+  (PAT) or OAuth token — instead of a key-pair JWT. The token is sent as
+  `Authorization: Bearer <token>` with no `X-Snowflake-Authorization-Token-Type` header
+  (Snowflake infers the type). Closes #161.
 
 ## [1.6.0] - 2026-04-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Available ENV variables (see below in the config section for details)
   - Use either the key or the path. Key takes precedence if both are provided.
 - `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE`
   - Optional, if you are using an encrypted private key
+- `SNOWFLAKE_ACCESS_TOKEN`
+  - Alternative to a private key: authenticate with a pre-issued bearer token — a
+    Programmatic Access Token (PAT) or OAuth token. When set, no private key is
+    required. (Also available as the `access_token:` keyword on `Client.new`.)
 - `SNOWFLAKE_ORGANIZATION`
   - Optional, if you leave it off, the library will authenticate with an account name of only SNOWFLAKE_ACCOUNT
 - `SNOWFLAKE_ACCOUNT`
@@ -216,7 +220,7 @@ end
 # Gotchas
 
 1. Does not yet support multiple statements (work around is to wrap in `BEGIN ... END`)
-2. Only supports key pair authentication
+2. Supports key-pair (JWT) and bearer-token (PAT / OAuth) authentication
 3. It's faster to work directly with the row value and not call to_h if you don't need to
 4. Rows are Enumerable, providing access to methods like `each`, `map`, `select`, `keys`, and `values`
 5. Row column access is case-insensitive and supports string keys, symbol keys, and numeric indices

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -85,13 +85,16 @@ module RubySnowflake
                       http_retries: env_option("SNOWFLAKE_HTTP_RETRIES", DEFAULT_HTTP_RETRIES),
                       query_timeout: env_option("SNOWFLAKE_QUERY_TIMEOUT", DEFAULT_QUERY_TIMEOUT),
                       default_role: env_option("SNOWFLAKE_DEFAULT_ROLE", DEFAULT_ROLE))
+      access_token = ENV["SNOWFLAKE_ACCESS_TOKEN"]
       private_key =
         if key = ENV["SNOWFLAKE_PRIVATE_KEY"]
           key
         elsif path = ENV["SNOWFLAKE_PRIVATE_KEY_PATH"]
           File.read(path)
+        elsif access_token
+          nil # authenticating with a bearer token (PAT/OAuth); no key needed
         else
-          raise MissingConfig, "Either ENV['SNOWFLAKE_PRIVATE_KEY'] or ENV['SNOWFLAKE_PRIVATE_KEY_PATH'] must be set"
+          raise MissingConfig, "Set ENV['SNOWFLAKE_ACCESS_TOKEN'], or ENV['SNOWFLAKE_PRIVATE_KEY'] / ENV['SNOWFLAKE_PRIVATE_KEY_PATH']"
         end
 
       new(
@@ -104,6 +107,7 @@ module RubySnowflake
         ENV["SNOWFLAKE_DEFAULT_WAREHOUSE"],
         ENV["SNOWFLAKE_DEFAULT_DATABASE"],
         default_role: ENV.fetch("SNOWFLAKE_DEFAULT_ROLE", nil),
+        access_token: access_token,
         logger: logger,
         log_level: log_level,
         jwt_token_ttl: jwt_token_ttl,
@@ -119,6 +123,7 @@ module RubySnowflake
     def initialize(
       uri, private_key, private_key_passphrase = nil, organization, account, user, default_warehouse, default_database,
       default_role: nil,
+      access_token: nil,
       logger: DEFAULT_LOGGER,
       log_level: DEFAULT_LOG_LEVEL,
       jwt_token_ttl: DEFAULT_JWT_TOKEN_TTL,
@@ -130,6 +135,7 @@ module RubySnowflake
       query_timeout: DEFAULT_QUERY_TIMEOUT
     )
       @base_uri = uri
+      @access_token = access_token
       @key_pair_jwt_auth_manager =
         KeyPairJwtAuthManager.new(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase)
       @default_warehouse = default_warehouse
@@ -212,13 +218,27 @@ module RubySnowflake
         @port ||= URI.parse(@base_uri).port
       end
 
+      # Authenticate with a pre-issued bearer token (a Programmatic Access Token or
+      # OAuth token) when one was supplied, otherwise mint a key-pair JWT. A bearer
+      # token is sent with no X-Snowflake-Authorization-Token-Type header — Snowflake
+      # infers the type (the header is optional per the SQL API docs).
+      def auth_headers
+        if @access_token
+          { "Authorization" => "Bearer #{@access_token}" }
+        else
+          {
+            "Authorization" => "Bearer #{@key_pair_jwt_auth_manager.jwt_token}",
+            "X-Snowflake-Authorization-Token-Type" => "KEYPAIR_JWT"
+          }
+        end
+      end
+
       def request_with_auth_and_headers(connection, request_class, path, body=nil)
         uri = URI.parse("#{@base_uri}#{path}")
         request = request_class.new(uri)
         request["Content-Type"] = "application/json"
         request["Accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@key_pair_jwt_auth_manager.jwt_token}"
-        request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
+        auth_headers.each { |name, value| request[name] = value }
         request.body = body unless body.nil?
 
         Retryable.retryable(tries: @http_retries + 1,

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -22,6 +22,33 @@ RSpec.describe RubySnowflake::Client do
     end
   end
 
+  describe "authentication headers" do
+    let(:uri) { "https://org-account.snowflakecomputing.com" }
+    let(:rsa_pem) { OpenSSL::PKey::RSA.new(2048).to_pem }
+
+    def build(private_key:, access_token: nil)
+      described_class.new(uri, private_key, "org", "account", "user", "wh", "db", access_token: access_token)
+    end
+
+    context "with a bearer access token (PAT / OAuth)" do
+      it "sends the token as a Bearer with no token-type header" do
+        headers = build(private_key: "unused", access_token: "the-pat-secret").send(:auth_headers)
+
+        expect(headers["Authorization"]).to eq("Bearer the-pat-secret")
+        expect(headers).not_to have_key("X-Snowflake-Authorization-Token-Type")
+      end
+    end
+
+    context "without an access token (key-pair JWT)" do
+      it "sends a signed JWT with the KEYPAIR_JWT token-type header" do
+        headers = build(private_key: rsa_pem).send(:auth_headers)
+
+        expect(headers["Authorization"]).to match(/\ABearer .+/)
+        expect(headers["X-Snowflake-Authorization-Token-Type"]).to eq("KEYPAIR_JWT")
+      end
+    end
+  end
+
   describe "querying" do
     subject(:result) { client.query(query, query_name: "test_query") }
     let(:query) { "SELECT 1;" }


### PR DESCRIPTION
Closing this. I was pairing with an agent and it opened the PR before I'd reviewed it. 
I'll reopen a cleaned-up version from our org fork


## What

Adds an `access_token:` option to `Client.new` / `Client.from_env` (env: `SNOWFLAKE_ACCESS_TOKEN`) so you can authenticate with a **pre-issued bearer token** — a Snowflake [Programmatic Access Token (PAT)](https://docs.snowflake.com/en/user-guide/programmatic-access-tokens) or OAuth token — instead of a key-pair JWT.

When a token is supplied it's sent as `Authorization: Bearer <token>` with **no** `X-Snowflake-Authorization-Token-Type` header (that header is optional per the SQL API docs; Snowflake infers the token type). Key-pair auth is completely unchanged when no token is given, so this is backward-compatible.

## Why not just pass the PAT as `SNOWFLAKE_PRIVATE_KEY`?

That workaround (floated in #161) can't work with the current code: the "private key" isn't forwarded as a bearer — it's used to **sign** a JWT (`KeyPairJwtAuthManager` does `OpenSSL::PKey.read(...)` then `JWT.encode(..., "RS256")`). A PAT is an opaque token, not a PEM key, so `OpenSSL::PKey.read` raises before any request is made. The token has to bypass the JWT path, which is what this change does.

## Testing

- New unit specs in `client_spec.rb` (`auth_headers`) covering both paths — token → `Bearer` with no token-type header; key-pair → signed JWT + `KEYPAIR_JWT`. No live Snowflake needed.
- Verified end-to-end against the SQL API v2 with a real PAT (auth succeeds, `ROLE_RESTRICTION` is honored).

## Notes

Kept intentionally minimal/additive (a single `access_token:` option). If you'd prefer a pluggable authenticator abstraction (`KeyPairAuthenticator` / `TokenAuthenticator`), happy to reshape it.