### PR TITLE
PLA-1043: bump concurrent-ruby + jwt (security)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,7 @@ GEM
     benchmark (0.5.0)
     bigdecimal (4.1.1)
     coderay (1.1.3)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     diff-lcs (1.6.2)
     dotenv (3.1.8)
@@ -38,7 +38,7 @@ GEM
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     json (2.19.3)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     logger (1.7.0)
     method_source (1.1.0)


### PR DESCRIPTION
Lockfile-only bumps clearing both SLA-breaching HIGH alerts: concurrent-ruby 1.3.6→1.3.7 (#8), jwt 3.1.2→3.2.0 (#6). Replaces the earlier closed-unmerged Dependabot PR #154.

Linear: https://linear.app/rinsed/issue/PLA-1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)