### PR TITLE
Stop shipping Gemfile.lock in the published gem (clears 3 CRITICAL on every consumer)

### DIFF
--- a/rb_snowflake_client.gemspec
+++ b/rb_snowflake_client.gemspec
@@ -14,8 +14,23 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/rinsed-org/rb-snowflake-client"
   s.license = "MIT"
 
+  # Gemfile.lock is excluded deliberately, and it is a security fix rather than tidiness.
+  #
+  # A lockfile has no function inside a published gem -- Bundler resolves a consumer's tree from the
+  # dependency constraints below, never from a lockfile shipped in a dependency -- but container image
+  # scanners read any Gemfile.lock they find on disk as a manifest of what is installed. So our
+  # DEVELOPMENT lock became a vulnerability report against every consumer: an image that installs this
+  # gem gets .../gems/rb_snowflake_client-1.6.0/Gemfile.lock scanned, and the pinned
+  # concurrent-ruby 1.3.6, jwt 3.1.2 and json 2.15.1 are reported as CRITICAL findings on the consumer.
+  #
+  # That is all three CRITICAL findings on the DataExtract Lambda image, and they are unfixable there:
+  # the versions are ours, in our published artifact, and no bump on the consumer's side can move them.
+  # The runtime constraints (concurrent-ruby >= 1.2, json >= 2.1.0, jwt >= 2.7) are open-ended, so
+  # consumers already resolve their own versions and lose nothing by not receiving this file.
   s.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features|vendor)/}) }
+    `git ls-files -z`.split("\x0").reject do |f|
+      f.match(%r{\A(?:test|spec|features|vendor)/}) || f == "Gemfile.lock"
+    end
   end
 
   s.require_paths = ["lib"]


### PR DESCRIPTION
A lockfile has **no function inside a published gem** — Bundler resolves a consumer's tree from the gemspec's dependency constraints, never from a lockfile shipped inside a dependency.

Container image scanners, however, read *any* `Gemfile.lock` they find on disk as a manifest of what is installed. So our **development** lock has been acting as a vulnerability report against every consumer of this gem.

## Concretely

An image that installs this gem gets this path scanned:

```
/var/lang/lib/ruby/gems/3.4.0/gems/rb_snowflake_client-1.6.0/Gemfile.lock
```

and the versions pinned there are reported as findings **against the consumer**:

| Pinned in our lock | Reported as | Severity |
|---|---|---|
| `concurrent-ruby 1.3.6` | → 1.3.7 | CRITICAL |
| `jwt 3.1.2` | → 3.2.0 | CRITICAL |
| `json 2.15.1` | → 2.19.2 | CRITICAL |

That is **all three CRITICAL findings on the DataExtract Lambda image** — and they are unfixable from that side. The versions live inside our published artifact, so no bump in the consumer's own bundle can move them. The only lever is here.

## Consumers lose nothing

The runtime constraints are open-ended:

```ruby
s.add_dependency "concurrent-ruby", ">= 1.2"
s.add_dependency "json", ">= 2.1.0"
s.add_dependency "jwt", ">= 2.7"
```

Consumers already resolve their own versions and never consulted the shipped lockfile.

## Verified

Ran `gem build` against the change:

- `Gemfile.lock` — **gone** from the package
- `lib/` — all 11 files still shipped
- no key material included

Remaining package root is `README.md`, `CHANGELOG.md`, `LICENSE.txt`, `CODE_OF_CONDUCT.md`, `Gemfile`, `Rakefile`, `.gitignore`, `.github/*`, and the gemspec. The bare `Gemfile` is harmless — it carries constraints, not pins, so scanners take no versions from it. Happy to drop it and `.github/` too if you'd prefer a tighter package; I kept the change to the one file that causes the findings.

## Timing

This takes effect **on the next release**. A consumer's findings clear once it picks up a version built from this gemspec — not on merge. DataExtract will need a `rb_snowflake_client` bump afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)