### PR TITLE
Release v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.6.1] - 2026-08-18
+### Security
+- Bumped `json` to patch a format-string injection CVE (#169)
+- Bumped `concurrent-ruby` and `jwt` to patch CVEs (#182)
+### Changed
+- `Gemfile.lock` is no longer shipped inside the published gem. It has no function in a
+  consumer's dependency resolution, but image scanners read it as a manifest and reported our
+  development pins as CRITICAL findings against every consumer (#186)
+
 ## [1.6.0] - 2026-04-13
 ### Added
 - Support for passing a passphrase when using an encrypted private key for JWT authentication (#166)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rb_snowflake_client (1.6.0)
+    rb_snowflake_client (1.6.1)
       bigdecimal (>= 3.0)
       concurrent-ruby (>= 1.2)
       connection_pool (>= 2.4)

--- a/lib/ruby_snowflake/version.rb
+++ b/lib/ruby_snowflake/version.rb
@@ -1,3 +1,3 @@
 module RubySnowflake
-  VERSION = "1.6.0"
+  VERSION = "1.6.1"
 end


### PR DESCRIPTION
Patch release bundling everything merged since v1.6.0.

## What's in it

| PR | Change |
|----|--------|
| #169 | `json` bumped to patch a format-string injection CVE |
| #182 | `concurrent-ruby` + `jwt` bumped to patch CVEs |
| #186 | `Gemfile.lock` no longer shipped inside the published gem |

## Why patch, not minor

No runtime dependency constraints changed — the gemspec still declares `concurrent-ruby >= 1.2`, `json >= 2.1.0`, `jwt >= 2.7`. Consumers resolve exactly as they did on 1.6.0. Everything here is our development lockfile and gem packaging.

The one behavioral change for consumers is #186: installs of 1.6.1 no longer place a `Gemfile.lock` in the gem directory, so image scanners stop reporting our dev pins as CRITICAL findings against downstream images.

## This PR

- `lib/ruby_snowflake/version.rb` → 1.6.1
- `Gemfile.lock` `PATH` spec → 1.6.1
- CHANGELOG entry for 1.6.1

## Verification

`gem build rb_snowflake_client.gemspec` produces `rb_snowflake_client-1.6.1.gem`, and the packaged file list contains `Gemfile` and `lib/ruby_snowflake/version.rb` but no `Gemfile.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)