### PR TITLE
Stop losing a query to a JWT Snowflake has refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- A key-pair JWT that Snowflake refuses no longer costs the query carrying it. `401` joins the
+  retryable response codes (Snowflake reports an expired JWT as `401` / `390144`, not the `403`
+  the retry list assumed), the auth headers are built inside the retry rather than before it, and
+  a `401` discards the cached token so the retry signs a new one. Fixes #170
+- `KeyPairJwtAuthManager` no longer caches a token for a full TTL that it never managed to sign.
+  The expiry was stamped before signing, so a signing failure left no token at all — every
+  request until the stamp elapsed sent an empty bearer — and the unsynchronised read could hand
+  back the previous token. The token is now published with its deadline only once signing has
+  succeeded, and re-signed at 80% of the TTL rather than in its final second
 
 ## [1.6.1] - 2026-08-18
 ### Security

--- a/lib/ruby_snowflake/client.rb
+++ b/lib/ruby_snowflake/client.rb
@@ -70,6 +70,7 @@ module RubySnowflake
     JSON_PARSE_OPTIONS = { decimal_class: BigDecimal }.freeze
     VALID_RESPONSE_CODES = %w(200 202).freeze
     POLLING_RESPONSE_CODE = "202"
+    UNAUTHORIZED_RESPONSE_CODE = "401"
     POLLING_INTERVAL = 2 # seconds
 
     # can't be set after initialization
@@ -217,14 +218,15 @@ module RubySnowflake
         request = request_class.new(uri)
         request["Content-Type"] = "application/json"
         request["Accept"] = "application/json"
-        request["Authorization"] = "Bearer #{@key_pair_jwt_auth_manager.jwt_token}"
-        request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
         request.body = body unless body.nil?
 
         Retryable.retryable(tries: @http_retries + 1,
                             sleep: lambda {|n| 2**n }, # 1, 2, 4, 8, etc
                             on: [RetryableBadResponseError, OpenSSL::SSL::SSLError],
                             log_method: retryable_log_method) do
+          # Inside the retry, so that a retry after a refused token carries the new one.
+          request["Authorization"] = "Bearer #{@key_pair_jwt_auth_manager.jwt_token}"
+          request["X-Snowflake-Authorization-Token-Type"] = "KEYPAIR_JWT"
           response = nil
           bm = Benchmark.measure { response = connection.request(request) }
           logger.debug { "HTTP Request time: #{bm.real}" }
@@ -235,6 +237,8 @@ module RubySnowflake
 
       def raise_on_bad_response(response)
         return if VALID_RESPONSE_CODES.include? response.code
+
+        @key_pair_jwt_auth_manager.expire_token! if response.code == UNAUTHORIZED_RESPONSE_CODE
 
         # there are a class of errors we want to retry rather than just giving up
         if retryable_http_response_code?(response.code)
@@ -250,10 +254,12 @@ module RubySnowflake
       # shamelessly stolen from the battle tested python client
       # https://github.com/snowflakedb/snowflake-connector-python/blob/eceed981f93e29d2f4663241253b48340389f4ef/src/snowflake/connector/network.py#L191
       def retryable_http_response_code?(code)
-        # retry (in order): bad request, forbidden (token expired in flight), method not allowed,
-        # request timeout, too many requests, anything in the 500 range (504 is fairly common),
-        # anything in the 3xx range as those are mostly "redirect" responses
-        [400, 403, 405, 408, 429].include?(code.to_i) || (500..599).include?(code.to_i) ||
+        # retry (in order): bad request, unauthorized (the key-pair JWT expired in flight, which
+        # Snowflake reports as 401 / 390144 rather than the 403 the python client expects),
+        # forbidden (token expired in flight), method not allowed, request timeout, too many
+        # requests, anything in the 500 range (504 is fairly common), anything in the 3xx range as
+        # those are mostly "redirect" responses
+        [400, 401, 403, 405, 408, 429].include?(code.to_i) || (500..599).include?(code.to_i) ||
          (300..399).include?(code.to_i)
       end
 

--- a/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
+++ b/lib/ruby_snowflake/client/key_pair_jwt_auth_manager.rb
@@ -7,6 +7,17 @@ require "concurrent"
 module RubySnowflake
   class Client
     class KeyPairJwtAuthManager
+      # Snowflake judges `exp` against its own clock, so the last seconds of a token's window are
+      # not ours to spend - re-sign once this much of its life has gone instead.
+      REFRESH_RATIO = 0.8
+
+      # One object so that a reader cannot see the token without the deadline that goes with it.
+      CachedToken = Struct.new(:value, :refresh_at) do
+        def fresh?(now)
+          now < refresh_at
+        end
+      end
+
       # requires text of a PEM formatted RSA private key
       def initialize(organization, account, user, private_key, jwt_token_ttl, private_key_passphrase = nil)
         @organization = organization
@@ -16,33 +27,44 @@ module RubySnowflake
         @jwt_token_ttl = jwt_token_ttl
         @private_key_passphrase = private_key_passphrase
 
-        # start with an expired value to force creation
-        @token_expires_at = Time.now.to_i - 1
+        @cached_token = Concurrent::AtomicReference.new(nil)
         @token_semaphore = Concurrent::Semaphore.new(1)
       end
 
       def jwt_token
-        return @token unless jwt_token_expired?
+        cached = @cached_token.get
+        return cached.value if cached&.fresh?(Time.now.to_i)
 
         @token_semaphore.acquire do
+          cached = @cached_token.get
+          next cached.value if cached&.fresh?(Time.now.to_i)
+
+          sign_token.tap { |token| @cached_token.set(token) }.value
+        end
+      end
+
+      # For when Snowflake has refused the token we hold: the next request signs a new one.
+      def expire_token!
+        @cached_token.set(nil)
+      end
+
+      private
+        def sign_token
           now = Time.now.to_i
-          @token_expires_at = now + @jwt_token_ttl
           private_key = OpenSSL::PKey.read(@private_key_pem, @private_key_passphrase)
 
           payload = {
             :iss => "#{account_name}.#{@user.upcase}.#{public_key_fingerprint}",
             :sub => "#{account_name}.#{@user.upcase}",
             :iat => now,
-            :exp => @token_expires_at
+            :exp => now + @jwt_token_ttl
           }
 
-          @token = JWT.encode payload, private_key, "RS256"
+          CachedToken.new(JWT.encode(payload, private_key, "RS256"), now + refresh_interval)
         end
-      end
 
-      private
-        def jwt_token_expired?
-          Time.now.to_i > @token_expires_at
+        def refresh_interval
+          (@jwt_token_ttl * REFRESH_RATIO).floor
         end
 
         def account_name

--- a/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
+++ b/spec/ruby_snowflake/client/key_pair_jwt_auth_manager_spec.rb
@@ -64,6 +64,56 @@ RSpec.describe RubySnowflake::Client::KeyPairJwtAuthManager do
     end
   end
   
+  describe "token caching" do
+    let(:jwt_token_ttl) { 3540 }
+    let(:minted_at) { Time.now.to_i }
+
+    before { travel_to(minted_at) }
+
+    def travel_to(seconds)
+      allow(Time).to receive(:now).and_return(Time.at(seconds))
+    end
+
+    it "reuses the signed token rather than signing one per request" do
+      subject.jwt_token
+
+      expect(JWT).not_to receive(:encode)
+      subject.jwt_token
+    end
+
+    it "keeps using it up to 80% of the token's life" do
+      subject.jwt_token
+      travel_to(minted_at + (jwt_token_ttl * 0.79).to_i)
+
+      expect(JWT).not_to receive(:encode)
+      subject.jwt_token
+    end
+
+    it "signs a new one past that point, while the old one is still valid" do
+      subject.jwt_token
+      travel_to(minted_at + (jwt_token_ttl * 0.8).to_i)
+
+      expect(JWT).to receive(:encode).once.and_call_original
+      subject.jwt_token
+    end
+
+    it "signs a new one once the token it holds has been rejected" do
+      subject.jwt_token
+      subject.expire_token!
+
+      expect(JWT).to receive(:encode).once.and_call_original
+      subject.jwt_token
+    end
+
+    it "does not go a whole TTL unsigned because one signing attempt failed" do
+      allow(JWT).to receive(:encode).and_raise(JWT::EncodeError)
+      expect { subject.jwt_token }.to raise_error(JWT::EncodeError)
+
+      allow(JWT).to receive(:encode).and_call_original
+      expect(subject.jwt_token).to be_a(String)
+    end
+  end
+
   describe "account_name handling" do
     context "when organization is nil" do
       let(:organization) { nil }

--- a/spec/ruby_snowflake/client_spec.rb
+++ b/spec/ruby_snowflake/client_spec.rb
@@ -22,6 +22,50 @@ RSpec.describe RubySnowflake::Client do
     end
   end
 
+  describe "when Snowflake refuses the token" do
+    subject(:request) { client.send(:request_with_auth_and_headers, connection, Net::HTTP::Post, "/api/v2/statements") }
+
+    let(:client) do
+      described_class.new(
+        "https://org-account.snowflakecomputing.com", OpenSSL::PKey::RSA.new(2048).to_pem, nil,
+        "org", "account", "user", nil, nil,
+        http_retries: 1, logger: Logger.new(IO::NULL)
+      )
+    end
+    let(:connection) { double("connection") }
+    let(:refused) { double("response", code: "401", body: %({"code": "390144", "message": "JWT token is invalid. "})) }
+    let(:accepted) { double("response", code: "200", body: "{}") }
+
+    before { allow(Kernel).to receive(:sleep) }
+
+    it "signs a fresh token and tries again" do
+      expect(connection).to receive(:request).twice.and_return(refused, accepted)
+      expect(JWT).to receive(:encode).twice.and_call_original
+
+      expect(request).to eq(accepted)
+    end
+
+    it "sends the new token rather than the one that was refused" do
+      sent = []
+      allow(connection).to receive(:request) do |request|
+        sent << request["Authorization"]
+        sent.one? ? refused : accepted
+      end
+      allow(JWT).to receive(:encode).and_return("first-token", "second-token")
+
+      request
+
+      expect(sent).to eq(["Bearer first-token", "Bearer second-token"])
+    end
+
+    it "still gives up rather than retrying a credential that is simply wrong" do
+      allow(connection).to receive(:request).and_return(refused)
+
+      expect { request }.to raise_error(RubySnowflake::Error, /401/)
+      expect(connection).to have_received(:request).twice
+    end
+  end
+
   describe "querying" do
     subject(:result) { client.query(query, query_name: "test_query") }
     let(:query) { "SELECT 1;" }


### PR DESCRIPTION
Fixes #170

Snowflake reports a refused key-pair JWT as `401` / `390144`, and three things combine to make that
kill the query that triggers it:

- `retryable_http_response_code?` retries `400, 403, 405, 408, 429`. Its comment says "forbidden
  (token expired in flight)" and lists `403`, but the code Snowflake actually sends is `401`.
- The auth headers are set before `Retryable.retryable`, so even if `401` were retryable the retry
  would re-send the token that had just been refused.
- `KeyPairJwtAuthManager#jwt_token` stamps the expiry *before* it signs. If signing raises, the
  stamp stands a full TTL ahead with `@token` still `nil`, and every request until then sends a
  bare `Bearer ` — Snowflake answers `"JWT token is invalid. null"`, the `null` showing no token
  arrived at all. The fast path also reads outside the semaphore, so a caller landing mid-refresh
  gets the previous token.

We saw both variants in production as bursts lasting roughly one token lifetime and then clearing
on their own, which is what a cache poisoned for a whole TTL looks like.

The fix: publish the token and the point we stop trusting it together, and only once signing has
succeeded; re-sign at 80% of the TTL rather than in its final second; make `401` retryable, move
the headers inside the retry, and discard the cached token on a `401` so the retry signs a new one.
Those last three only work together — any one alone still re-sends a rejected credential.

Eight new specs, all offline, no Snowflake account needed:

```
bundle exec rspec spec/ruby_snowflake/client/
bundle exec rspec spec/ruby_snowflake/client_spec.rb -e initialization -e "when Snowflake refuses the token"
```

The rest of `client_spec.rb` needs live credentials so it isn't run here. One caveat on
verification: every connection we can reach from a dev machine authenticates with a PAT, so the
key-pair path is covered by unit tests rather than a real 401 driven end to end. Changelog updated
under Unreleased. Happy to change any of the approach.
